### PR TITLE
Fix error while rendering links with absolute URI inside of <sup> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.9
+- Fix a bug that raised error while rendering links with absolute URI inside of `<sup>` tag (e.g. `<sup>[Qiita](http://qiita.com/)</sup>`)
+
 ## 0.1.8
 - Add title attribute into footnote link element
 

--- a/lib/qiita/markdown/filters/footnote.rb
+++ b/lib/qiita/markdown/filters/footnote.rb
@@ -4,7 +4,8 @@ module Qiita
       class Footnote < HTML::Pipeline::Filter
         def call
           doc.search("sup > a").each do |a|
-            if li = doc.search(a["href"]).first
+            href = a["href"]
+            if href.start_with?("#") && (li = doc.search(href).first)
               a[:title] = li.text.gsub(/\A\n/, "").gsub(/ ↩\n\z/, "")
             end
           end

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -528,5 +528,19 @@ describe Qiita::Markdown::Processor do
         EOS
       end
     end
+
+    context 'with manually written link inside of <sup> tag' do
+      let(:markdown) do
+        <<-EOS.strip_heredoc
+          <sup>[Qiita](http://qiita.com/)</sup>
+        EOS
+      end
+
+      it "does not confuse the structure with automatically generated footnote reference" do
+        should eq <<-EOS.strip_heredoc
+          <p><sup><a href="http://qiita.com/">Qiita</a></sup></p>
+        EOS
+      end
+    end
   end
 end


### PR DESCRIPTION
Without this fix it raised the following error:

```
     Nokogiri::CSS::SyntaxError:
       unexpected '//' after ':'
     # ./lib/qiita/markdown/filters/footnote.rb:8:in `block in call'
     # ./lib/qiita/markdown/filters/footnote.rb:6:in `call'
     # ./lib/qiita/markdown/processor.rb:37:in `call'
```
