### PR TITLE
Fix error on rendering <a> tag with strange href inside of <sup> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.2
+- Fix a bug that raised error on rendering `<a>` tag with href for unknown fragment inside of `<sup>` tag (e.g. `<sup><a href="#foo.1">Link</a></sup>`)
+
 ## 0.2.1
 - Strengthen sanitization (thx xrekkusu)
 

--- a/lib/qiita/markdown/filters/footnote.rb
+++ b/lib/qiita/markdown/filters/footnote.rb
@@ -4,12 +4,19 @@ module Qiita
       class Footnote < HTML::Pipeline::Filter
         def call
           doc.search("sup > a").each do |a|
-            href = a["href"]
-            if href.start_with?("#") && (li = doc.search(href).first)
-              a[:title] = li.text.gsub(/\A\n/, "").gsub(/ ↩\n\z/, "")
-            end
+            footnote = find_footnote(a)
+            next unless footnote
+            a[:title] = footnote.text.gsub(/\A\n/, "").gsub(/ ↩\n\z/, "")
           end
           doc
+        end
+
+        private
+
+        def find_footnote(a)
+          href = a["href"]
+          return nil if !href || href.match(/\A#fn\d+\z/).nil?
+          doc.search(href).first
         end
       end
     end

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -561,5 +561,19 @@ describe Qiita::Markdown::Processor do
         EOS
       end
     end
+
+    context 'with manually written <a> tag with strange href inside of <sup> tag' do
+      let(:markdown) do
+        <<-EOS.strip_heredoc
+          <sup><a href="#foo.1">Link</a></sup>
+        EOS
+      end
+
+      it "does not confuse the structure with automatically generated footnote reference" do
+        should eq <<-EOS.strip_heredoc
+          <p><sup><a href="#foo.1">Link</a></sup></p>
+        EOS
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously, rendering the following markdown:

    <sup><a href="#foo.1">Link</a></sup>

raised the following error:

    Nokogiri::CSS::SyntaxError:
      unexpected '.1' after '[#<Nokogiri::CSS::Node:0x007fe22c1481b8 @type=:CONDITIONAL_SELECTOR, @value=[#<Nokogiri::CSS::Node:0x007fe22c148258 @type=:ELEMENT_NAME, @value=["*"]>, #<Nokogiri::CSS::Node:0x007fe22c148ac8 @type=:ID, @value=["#foo"]>]>]'