### PR TITLE
Avoid emphasizing mentions to username suffixed with underscore

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,10 +36,6 @@ Style/AndOr:
 Style/BarePercentLiterals:
   Enabled: false
 
-# Offense count: 1
-Style/ConstantName:
-  Enabled: false
-
 # Offense count: 10
 Style/Documentation:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Fix an issue that mentions to username suffixed with `_` and a preceding word prefixed with `_` were treated as emphasis (e.g. `_some_symbol @user_`).
 
 ## 0.3.0
 - Introduce another processor Qiita::Markdown::SummaryProcessor, which is for rendering a summary of markdown document.

--- a/lib/qiita/markdown/filters/mention.rb
+++ b/lib/qiita/markdown/filters/mention.rb
@@ -6,7 +6,7 @@ module Qiita
       #
       # You can pass :allowed_usernames context to limit mentioned usernames.
       class Mention < HTML::Pipeline::MentionFilter
-        MentionPattern = /
+        MENTION_PATTERN = /
           (?:^|\W)
           @((?>[\w][\w-]{1,30}\w(?:@github)?))
           (?!\/)
@@ -20,7 +20,7 @@ module Qiita
 
         # @note Override to use customized MentionPattern and allowed_usernames logic.
         def mention_link_filter(text, _, _)
-          text.gsub(MentionPattern) do |match|
+          text.gsub(MENTION_PATTERN) do |match|
             name = $1
             if allowed_usernames && !allowed_usernames.include?(name)
               match

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -274,6 +274,20 @@ describe Qiita::Markdown::Processor do
       end
     end
 
+    context "with mention to a user suffixed with _ and a preceding word prefixed with _" do
+      let(:markdown) do
+        <<-EOS.strip_heredoc
+          _symbol @user_
+        EOS
+      end
+
+      it "does not treat the mention as a part of emphasis" do
+        should eq <<-EOS.strip_heredoc
+          <p>_symbol <a href="/user_" class="user-mention" title="user_">@user_</a></p>
+        EOS
+      end
+    end
+
     context "with allowed_usernames context" do
       before do
         context[:allowed_usernames] = ["alice"]


### PR DESCRIPTION
Given a markdown source:

```
_some_symbol @user_
```

Previously it was rendered as:

![screen shot 2015-03-20 at 13 59 59](https://cloud.githubusercontent.com/assets/83656/6746347/f74690e0-cf09-11e4-91d8-a5f36658b2ca.png)

Now it's rendered as:

![screen shot 2015-03-20 at 14 02 12](https://cloud.githubusercontent.com/assets/83656/6746350/0da0d832-cf0a-11e4-8fd1-2588529ed285.png)
