### PR TITLE
Fix backward incompatibility of heading fragment identifiers in v0.5.0

### DIFF
--- a/benchmark/heading_anchor_rendering.rb
+++ b/benchmark/heading_anchor_rendering.rb
@@ -160,11 +160,11 @@ module Rendering
           @counter ||= Hash.new(0)
         end
 
-        Heading = Struct.new(:text, :level, :counter) do
+        Heading = Struct.new(:body, :level, :counter) do
           # For reference, C implementation of Redcarpet::Render::HTML#header is the following:
           # https://github.com/vmg/redcarpet/blob/v3.2.3/ext/redcarpet/html.c#L281-L296
           def to_s
-            "\n<h#{level}>#{content}</h#{level}>\n"
+            "\n<h#{level}>#{body}</h#{level}>\n"
           end
 
           def increment
@@ -174,20 +174,20 @@ module Rendering
           private
 
           def content
-            text
+            body
           end
         end
 
         class HeadingWithAnchor < Heading
+          def to_s
+            "\n<h#{level}>#{anchor_element}#{body}</h#{level}>\n"
+          end
+
           def increment
             counter[id] += 1
           end
 
           private
-
-          def content
-            anchor_element + text
-          end
 
           def anchor_element
             %(<span id="#{suffixed_id}" class="fragment"></span><a href="##{suffixed_id}"><i class="fa fa-link"></i></a>)
@@ -203,6 +203,10 @@ module Rendering
 
           def id
             @id ||= text.downcase.gsub(/[^\p{Word}\- ]/u, "").gsub(" ", "-")
+          end
+
+          def text
+            Nokogiri::HTML.fragment(body).text
           end
 
           def suffix
@@ -234,12 +238,11 @@ end
 
 # Calculating -------------------------------------
 #         post process         4 i/100ms
-#            rendering        22 i/100ms
+#            rendering        14 i/100ms
 # -------------------------------------------------
-#         post process       48.3 (±16.6%) i/s -        236 in   5.027265s
-#            rendering      227.3 (±15.8%) i/s -       1122 in   5.084983s
+#         post process       44.9 (±13.4%) i/s -        224 in   5.066301s
+#            rendering      151.1 (±16.5%) i/s -        742 in   5.057789s
 #
 # Comparison:
-#            rendering:      227.3 i/s
-#         post process:       48.3 i/s - 4.70x slower
-#
+#            rendering:      151.1 i/s
+#         post process:       44.9 i/s - 3.36x slower

--- a/lib/qiita/markdown/greenmat/heading_rendering.rb
+++ b/lib/qiita/markdown/greenmat/heading_rendering.rb
@@ -6,7 +6,7 @@ module Qiita
           @counter ||= Hash.new(0)
         end
 
-        AbstractHeading = Struct.new(:text, :level, :counter) do
+        AbstractHeading = Struct.new(:body, :level, :counter) do
           def to_s
             fail NotImplementedError
           end
@@ -27,6 +27,10 @@ module Qiita
 
           def id
             @id ||= text.downcase.gsub(/[^\p{Word}\- ]/u, "").gsub(" ", "-")
+          end
+
+          def text
+            Nokogiri::HTML.fragment(body).text
           end
 
           def suffix

--- a/lib/qiita/markdown/greenmat/html_renderer.rb
+++ b/lib/qiita/markdown/greenmat/html_renderer.rb
@@ -26,7 +26,7 @@ module Qiita
           # For reference, C implementation of Redcarpet::Render::HTML#header is the following:
           # https://github.com/vmg/redcarpet/blob/v3.2.3/ext/redcarpet/html.c#L281-L296
           def to_s
-            "\n<h#{level}>#{text}</h#{level}>\n"
+            "\n<h#{level}>#{body}</h#{level}>\n"
           end
 
           def increment
@@ -36,7 +36,7 @@ module Qiita
 
         class HeadingWithAnchor < AbstractHeading
           def to_s
-            "\n<h#{level}>#{anchor_element}#{text}</h#{level}>\n"
+            "\n<h#{level}>#{anchor_element}#{body}</h#{level}>\n"
           end
 
           def increment

--- a/lib/qiita/markdown/greenmat/html_toc_renderer.rb
+++ b/lib/qiita/markdown/greenmat/html_toc_renderer.rb
@@ -54,7 +54,7 @@ module Qiita
 
         class HeadingAnchor < AbstractHeading
           def to_s
-            "<a href=\"##{suffixed_id}\">#{text}</a>\n"
+            "<a href=\"##{suffixed_id}\">#{body}</a>\n"
           end
 
           def increment

--- a/spec/qiita/markdown/greenmat/html_renderer_spec.rb
+++ b/spec/qiita/markdown/greenmat/html_renderer_spec.rb
@@ -31,6 +31,21 @@ describe Qiita::Markdown::Greenmat::HTMLRenderer do
           <h3><span id="a-3" class="fragment"></span><a href="#a-3"><i class="fa fa-link"></i></a>a</h3>
         EOS
       end
+
+      context "and heading title including special HTML characters" do
+        let(:markdown) do
+          <<-EOS.strip_heredoc
+            # <b>R&amp;B</b>
+          EOS
+        end
+
+        it "generates fragment identifier by sanitizing the characters in the title" do
+          should eq <<-EOS.strip_heredoc
+
+            <h1><span id="rb" class="fragment"></span><a href="#rb"><i class="fa fa-link"></i></a><b>R&amp;B</b></h1>
+          EOS
+        end
+      end
     end
 
     context "without :with_toc_data extension" do

--- a/spec/qiita/markdown/greenmat/html_toc_renderer_spec.rb
+++ b/spec/qiita/markdown/greenmat/html_toc_renderer_spec.rb
@@ -94,4 +94,22 @@ describe Qiita::Markdown::Greenmat::HTMLToCRenderer do
       EOS
     end
   end
+
+  context "with heading title including special HTML characters" do
+    let(:markdown) do
+      <<-EOS.strip_heredoc
+        # <b>R&amp;B</b>
+      EOS
+    end
+
+    it "generates fragment identifier by sanitizing the characters in the title" do
+      should eq <<-EOS.strip_heredoc
+        <ul>
+        <li>
+        <a href="#rb"><b>R&amp;B</b></a>
+        </li>
+        </ul>
+      EOS
+    end
+  end
 end


### PR DESCRIPTION
This fixes backward incompatibility of heading fragment identifiers that include special HTML characters in v0.5.0. For example, with Markdown document `# <b>R&amp;B</b>`, originally the fragment identifier for the heading was `#rb`. However in v0.5.0 it became `#brampb` unintentionally.

This change decreases the rendering performance a bit, but it's still faster than the previous post-process implementation.