### PR TITLE
Add :escape_html extension to Greenmat::HTMLToCRenderer

### DIFF
--- a/lib/qiita/markdown.rb
+++ b/lib/qiita/markdown.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/object/blank"
+require "cgi"
 require "greenmat"
 require "html/pipeline"
 require "linguist"

--- a/lib/qiita/markdown/greenmat/heading_rendering.rb
+++ b/lib/qiita/markdown/greenmat/heading_rendering.rb
@@ -6,7 +6,17 @@ module Qiita
           @counter ||= Hash.new(0)
         end
 
-        AbstractHeading = Struct.new(:body, :level, :counter) do
+        class AbstractHeading
+          attr_reader :raw_body, :level, :counter, :escape_html
+          alias_method :escape_html?, :escape_html
+
+          def initialize(raw_body, level, counter, escape_html = false)
+            @raw_body = raw_body
+            @level = level
+            @counter = counter
+            @escape_html = escape_html
+          end
+
           def to_s
             fail NotImplementedError
           end
@@ -25,12 +35,16 @@ module Qiita
             count > 0
           end
 
+          def body
+            escape_html? ? CGI.escape_html(raw_body) : raw_body
+          end
+
           def id
             @id ||= text.downcase.gsub(/[^\p{Word}\- ]/u, "").gsub(" ", "-")
           end
 
           def text
-            Nokogiri::HTML.fragment(body).text
+            Nokogiri::HTML.fragment(raw_body).text
           end
 
           def suffix

--- a/lib/qiita/markdown/greenmat/html_toc_renderer.rb
+++ b/lib/qiita/markdown/greenmat/html_toc_renderer.rb
@@ -4,8 +4,9 @@ module Qiita
       class HTMLToCRenderer < ::Greenmat::Render::HTML_TOC
         include HeadingRendering
 
-        def initialize(*)
+        def initialize(extensions = {})
           super
+          @extensions = extensions
           @last_level = 0
         end
 
@@ -32,7 +33,7 @@ module Qiita
         def generate_heading_html(text, level, level_difference)
           html = list_item_preceding_html(level_difference)
 
-          anchor = HeadingAnchor.new(text, level, heading_counter)
+          anchor = HeadingAnchor.new(text, level, heading_counter, escape_html?)
           html << anchor.to_s
           anchor.increment
 
@@ -50,6 +51,10 @@ module Qiita
                  end
 
           html << "<li>\n"
+        end
+
+        def escape_html?
+          @extensions[:escape_html]
         end
 
         class HeadingAnchor < AbstractHeading

--- a/spec/qiita/markdown/greenmat/html_toc_renderer_spec.rb
+++ b/spec/qiita/markdown/greenmat/html_toc_renderer_spec.rb
@@ -1,7 +1,8 @@
 require "active_support/core_ext/string/strip"
 
 describe Qiita::Markdown::Greenmat::HTMLToCRenderer do
-  let(:renderer) { described_class.new }
+  let(:renderer) { described_class.new(extension) }
+  let(:extension) { {} }
   let(:greenmat) { ::Greenmat::Markdown.new(renderer) }
   subject(:rendered_html) { greenmat.render(markdown) }
 
@@ -107,6 +108,26 @@ describe Qiita::Markdown::Greenmat::HTMLToCRenderer do
         <ul>
         <li>
         <a href="#rb"><b>R&amp;B</b></a>
+        </li>
+        </ul>
+      EOS
+    end
+  end
+
+  context "with :escape_html extension" do
+    let(:extension) { { escape_html: true } }
+
+    let(:markdown) do
+      <<-EOS.strip_heredoc
+        # <b>R&amp;B</b>
+      EOS
+    end
+
+    it "escapes special HTML characters in heading title" do
+      should eq <<-EOS.strip_heredoc
+        <ul>
+        <li>
+        <a href="#rb">&lt;b&gt;R&amp;amp;B&lt;/b&gt;</a>
         </li>
         </ul>
       EOS


### PR DESCRIPTION
This API is same as [`Redcarpet::Render::HTML_TOC`'s one](https://github.com/vmg/redcarpet/commit/3d71044c640383d91a190ed035223f4631c2b8b7), which is not yet released and will be released in Redcarpet 3.3.