### PR TITLE
fix filters configurations.

### DIFF
--- a/lib/qiita/markdown/processor.rb
+++ b/lib/qiita/markdown/processor.rb
@@ -39,7 +39,6 @@ module Qiita
       # @note Modify filters if you want.
       # @return [Array<HTML::Pipeline::Filter>]
       def filters
-        p @filters
         @filters ||= DEFAULT_FILTERS.clone
       end
     end

--- a/lib/qiita/markdown/processor.rb
+++ b/lib/qiita/markdown/processor.rb
@@ -39,7 +39,8 @@ module Qiita
       # @note Modify filters if you want.
       # @return [Array<HTML::Pipeline::Filter>]
       def filters
-        @filters ||= DEFAULT_FILTERS
+        p @filters
+        @filters ||= DEFAULT_FILTERS.clone
       end
     end
   end

--- a/lib/qiita/markdown/summary_processor.rb
+++ b/lib/qiita/markdown/summary_processor.rb
@@ -16,7 +16,7 @@ module Qiita
       # @note Modify filters if you want.
       # @return [Array<HTML::Pipeline::Filter>]
       def filters
-        @filters ||= DEFAULT_FILTERS
+        @filters ||= DEFAULT_FILTERS.clone
       end
     end
   end


### PR DESCRIPTION
If you push custom filters into `Qiita::Markdown::Processor` instance many times, another instance variables can refer the other one, and continuing to increase.
So it should have been used `dup` or `clone` method.