### PR TITLE
html-pipeline v2

### DIFF
--- a/lib/qiita/markdown/filters/mention.rb
+++ b/lib/qiita/markdown/filters/mention.rb
@@ -19,7 +19,7 @@ module Qiita
         /ix
 
         # @note Override to use customized MentionPattern and allowed_usernames logic.
-        def mention_link_filter(text, _, _)
+        def mention_link_filter(text, _, _, _)
           text.gsub(MentionPattern) do |match|
             name = $1
             case

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "gemoji"
   spec.add_dependency "github-linguist"
-  spec.add_dependency "html-pipeline"
+  spec.add_dependency "html-pipeline", "~> 2.0"
   spec.add_dependency "mem"
   spec.add_dependency "pygments.rb"
   spec.add_dependency "greenmat", ">= 3.2.0.2", "< 4"


### PR DESCRIPTION
`HTML::Pipeline::MentionFilter#mention_link_filter` takes four arguments by v2. This commit simply ignores the new one because it seems we don't need that.

https://github.com/brittballard/html-pipeline/commit/57f6cce37cd2e7f941a3b8371b9f6e7597512347

review plz @r7kamura 