### PR TITLE
Treat "hack" as an alias for "php"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ Style/StringLiterals:
 
 Style/TrailingComma:
   EnforcedStyleForMultiline: comma
+
+Style/UnneededPercentQ:
+  Enabled: false

--- a/lib/qiita/markdown/filters/code.rb
+++ b/lib/qiita/markdown/filters/code.rb
@@ -3,6 +3,7 @@ module Qiita
     module Filters
       DEFAULT_LANGUAGE_ALIASES = {
         "el" => "common-lisp",
+        "hack" => "php",
         "zsh" => "bash",
       }
 

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -112,6 +112,26 @@ describe Qiita::Markdown::Processor do
       end
     end
 
+    context "with code & filename with .php" do
+      let(:markdown) do
+        <<-EOS.strip_heredoc
+          ```example.php
+          1
+          ```
+        EOS
+      end
+
+      it "returns PHP code-frame" do
+        should eq <<-EOS.strip_heredoc
+          <div class="code-frame" data-lang="php">
+          <div class="code-lang"><span class="bold">example.php</span></div>
+          <div class="highlight"><pre><span class="mi">1</span>
+          </pre></div>
+          </div>
+        EOS
+      end
+    end
+
     context "with malicious script in filename" do
       let(:markdown) do
         <<-EOS.strip_heredoc


### PR DESCRIPTION
review plz @yujinakayama 

qiita-markdown uses liguist gem to detect code block languages from embedded file names,
and it returns `[Hack, PHP]` for files with ".php" extension. 

    Linguist::Language.find_by_filename('hoge.php')
    #=> [#<Linguist::Language name=Hack>, #<Linguist::Language name=PHP>]

Because qiita-markdown uses the first element as their language, this means that such code
blocks are detected as written in Hack language.

This commit let qiita-mardown treat "hack" as an alias for "php". By this, we can
highlight code blocks with not only such file name:

    ```hoge.php
    class SampleClass {
        public function hello() {
            return "world";
        }
    }
    ```

but also "hack" as its language:

    ```hack:hoge.php
    class SampleClass {
        public function hello() {
            return "world";
        }
    }
    ```

with PHP syntax highlighter.