### PR TITLE
Avoid stripping leading and trailing newlines in code snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.11.4
+- Avoid stripping leading and trailing newlines in code snippets
+
 ## 0.11.3
 - Ignore menton in blockquote element
 

--- a/lib/qiita/markdown/filters/syntax_highlight.rb
+++ b/lib/qiita/markdown/filters/syntax_highlight.rb
@@ -82,7 +82,7 @@ module Qiita
 
           def pygments_options
             @pygments_options ||= begin
-              options = { encoding: "utf-8" }
+              options = { encoding: "utf-8", stripnl: false }
               options[:startinline] = true if has_inline_php?
               options
             end

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -201,6 +201,27 @@ describe Qiita::Markdown::Processor do
       end
     end
 
+    context "with code with leading and trailing newlines" do
+      let(:markdown) do
+        <<-EOS.strip_heredoc
+          ```
+
+          foo
+
+          ```
+        EOS
+      end
+
+      it "does not strip the newlines" do
+        should eq <<-EOS.strip_heredoc
+          <div class="code-frame" data-lang="text"><div class="highlight"><pre>
+          foo
+
+          </pre></div></div>
+         EOS
+      end
+    end
+
     context "with script element" do
       let(:markdown) do
         <<-EOS.strip_heredoc


### PR DESCRIPTION
By default pygments' lexer automatically strips leading/trailing newlines in code snippets, but we want to leave them as they are.

https://github.com/tmm1/pygments.rb/blob/v0.6.3/vendor/pygments-main/pygments/lexer.py#L51-L52