### PR TITLE
Add leading newline to <pre> element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /coverage/
 /doc/
 /pkg/
+/spec/examples.txt
 /spec/reports/
 /tmp/
 *.bundle

--- a/lib/qiita/markdown/filters/code.rb
+++ b/lib/qiita/markdown/filters/code.rb
@@ -28,6 +28,9 @@ module Qiita
                 filename: filename,
                 language: language,
               }
+              # a leading newline character immediately following the pre element start tag is stripped.
+              # http://dev.w3.org/html5/spec-preview/the-pre-element.html
+              pre.content = "\n#{pre.content}"
             end
           end
           doc

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -117,7 +117,8 @@ describe Qiita::Markdown::Processor do
         should eq <<-EOS.strip_heredoc
           <div class="code-frame" data-lang="ruby">
           <div class="code-lang"><span class="bold">example.rb</span></div>
-          <div class="highlight"><pre><span class="mi">1</span>
+          <div class="highlight"><pre>
+          <span class="mi">1</span>
           </pre></div>
           </div>
         EOS
@@ -137,7 +138,8 @@ describe Qiita::Markdown::Processor do
         should eq <<-EOS.strip_heredoc
           <div class="code-frame" data-lang="php">
           <div class="code-lang"><span class="bold">example.php</span></div>
-          <div class="highlight"><pre><span class="mi">1</span>
+          <div class="highlight"><pre>
+          <span class="mi">1</span>
           </pre></div>
           </div>
         EOS
@@ -157,7 +159,8 @@ describe Qiita::Markdown::Processor do
         should eq <<-EOS.strip_heredoc
           <div class="code-frame" data-lang="js">
           <div class="code-lang"><span class="bold">test</span></div>
-          <div class="highlight"><pre><span class="mi">1</span>
+          <div class="highlight"><pre>
+          <span class="mi">1</span>
           </pre></div>
           </div>
         EOS
@@ -175,7 +178,8 @@ describe Qiita::Markdown::Processor do
 
       it "returns code-frame and highlighted pre element" do
         should eq <<-EOS.strip_heredoc
-          <div class="code-frame" data-lang="ruby"><div class="highlight"><pre><span class="mi">1</span>
+          <div class="code-frame" data-lang="ruby"><div class="highlight"><pre>
+          <span class="mi">1</span>
           </pre></div></div>
         EOS
       end
@@ -215,6 +219,7 @@ describe Qiita::Markdown::Processor do
       it "does not strip the newlines" do
         should eq <<-EOS.strip_heredoc
           <div class="code-frame" data-lang="text"><div class="highlight"><pre>
+
           foo
 
           </pre></div></div>
@@ -359,7 +364,8 @@ describe Qiita::Markdown::Processor do
         should include(<<-EOS.strip_heredoc.rstrip)
           <div class="code-frame" data-lang="ruby">
           <div class="code-lang"><span class="bold">@alice</span></div>
-          <div class="highlight"><pre><span class="mi">1</span>
+          <div class="highlight"><pre>
+          <span class="mi">1</span>
           </pre></div>
           </div>
         EOS
@@ -623,7 +629,8 @@ describe Qiita::Markdown::Processor do
 
       it "does not replace checkbox" do
         should eq <<-EOS.strip_heredoc
-          <div class="code-frame" data-lang="text"><div class="highlight"><pre>- [ ] a
+          <div class="code-frame" data-lang="text"><div class="highlight"><pre>
+          - [ ] a
           - [x] b
           </pre></div></div>
         EOS

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,4 +17,6 @@ RSpec.configure do |config|
   config.default_formatter = "doc"
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
+
+  config.example_status_persistence_file_path = "spec/examples.txt"
 end


### PR DESCRIPTION
As the HTML specification describes:

> Note: In the HTML syntax, a leading newline character immediately following the pre element start tag is stripped.

http://dev.w3.org/html5/spec-preview/the-pre-element.html

... we need to add a leading newline to the content of `<pre>` element so that the original leading newlines inputted by user are properly rendered on browsers.

## Before

<img width="616" alt="screen shot 2016-01-14 at 20 29 42" src="https://cloud.githubusercontent.com/assets/83656/12323327/b1a79a9e-bafd-11e5-9738-2871a95d43e6.png">

## After

<img width="616" alt="screen shot 2016-01-14 at 20 30 56" src="https://cloud.githubusercontent.com/assets/83656/12323330/badaa214-bafd-11e5-89e3-6031b902efd5.png">
