### PR TITLE
Fix the activesupport version to support  Ruby versions (less than 2.3)

### DIFF
--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pygments.rb"
   spec.add_dependency "greenmat", ">= 3.2.0.2", "< 4"
   spec.add_dependency "sanitize"
-  spec.add_development_dependency "activesupport"
+  spec.add_development_dependency "activesupport", "4.2.6"
   spec.add_development_dependency "benchmark-ips", "~> 1.2"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "codeclimate-test-reporter", "0.4.4"


### PR DESCRIPTION
Ruby versions which are less than 2.3 are NOT supported by the new activesupport version (5 series). Thus, currently, the build result by Travis CI was "failed" on the target Ruby versions. To fix this issue, fix the activesupport version.