### PR TITLE
Add some attributes to a elements for hover card

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,6 @@ Style/TrailingCommaInLiteral:
 
 Style/UnneededPercentQ:
   Enabled: false
+
+Metrics/LineLength:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,12 +10,6 @@
 Metrics/AbcSize:
   Max: 21
 
-# Offense count: 37
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 121
-
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/MethodLength:

--- a/lib/qiita/markdown/filters/mention.rb
+++ b/lib/qiita/markdown/filters/mention.rb
@@ -53,7 +53,7 @@ module Qiita
               url = File.join(base_url, name)
               match.sub(
                 "@#{name}",
-                %[<a href="#{url}" class="user-mention" title="#{name}">@#{name}</a>]
+                %[<a href="#{url}" class="user-mention js-hovercard" title="#{name}" data-hovercard-target-type="user" data-hovercard-target-name="#{name}">@#{name}</a>]
               )
             end
           end

--- a/lib/qiita/markdown/filters/sanitize.rb
+++ b/lib/qiita/markdown/filters/sanitize.rb
@@ -46,6 +46,8 @@ module Qiita
         RULE = {
           attributes: {
             "a" => [
+              "data-hovercard-target-name",
+              "data-hovercard-target-type",
               "href",
             ],
             "iframe" => [

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -294,7 +294,7 @@ describe Qiita::Markdown::Processor do
 
       it "replaces mention with link" do
         should include(<<-EOS.strip_heredoc.rstrip)
-          <a href="/alice" class="user-mention" title="alice">@alice</a>
+          <a href="/alice" class="user-mention js-hovercard" title="alice" data-hovercard-target-type="user" data-hovercard-target-name="alice">@alice</a>
         EOS
       end
     end
@@ -306,7 +306,7 @@ describe Qiita::Markdown::Processor do
 
       it "replaces mention with link" do
         should include(<<-EOS.strip_heredoc.rstrip)
-          <a href="/al" class="user-mention" title="al">@al</a>
+          <a href="/al" class="user-mention js-hovercard" title="al" data-hovercard-target-type="user" data-hovercard-target-name="al">@al</a>
         EOS
       end
     end
@@ -393,7 +393,7 @@ describe Qiita::Markdown::Processor do
 
       it "does not emphasize the name" do
         should include(<<-EOS.strip_heredoc.rstrip)
-          <a href="/_alice_" class="user-mention" title="_alice_">@_alice_</a>
+          <a href="/_alice_" class="user-mention js-hovercard" title="_alice_" data-hovercard-target-type="user" data-hovercard-target-name="_alice_">@_alice_</a>
         EOS
       end
     end

--- a/spec/qiita/markdown/summary_processor_spec.rb
+++ b/spec/qiita/markdown/summary_processor_spec.rb
@@ -240,7 +240,7 @@ describe Qiita::Markdown::SummaryProcessor do
       end
 
       it "replaces mention with link" do
-        should eq %{<a href="/alice" class="user-mention" title="alice">@alice</a>\n}
+        should eq %{<a href="/alice" class="user-mention js-hovercard" title="alice" data-hovercard-target-type="user" data-hovercard-target-name="alice">@alice</a>\n}
       end
     end
   end


### PR DESCRIPTION
This PR adds `class="js-user-hover-card"` and `data-user-url-name` attributes to `A` elements generated by the mention filter to implement user hover card feature in Qiita core.

@r7kamura, could you review this PR?