### PR TITLE
Add rel="noopener" to external links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## master
+- Add rel=noopener to all external a tags
+
 ## 0.15.0
 - Append rel=nofollow and target=_blank to all external a tags
 

--- a/lib/qiita/markdown/filters/external_link.rb
+++ b/lib/qiita/markdown/filters/external_link.rb
@@ -11,7 +11,7 @@ module Qiita
             href_host = host_of(href)
             next unless href_host
             if href_host != hostname
-              anchor["rel"] = "nofollow"
+              anchor["rel"] = "nofollow noopener"
               anchor["target"] = "_blank"
             end
           end

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -482,7 +482,7 @@ describe Qiita::Markdown::Processor do
 
       it "replaces it with preferred link and updates :mentioned_groups" do
         is_expected.to eq <<-EOS.strip_heredoc
-          <p><a href="https://alice.example.com/groups/bob" rel="nofollow" target="_blank">@alice/bob</a></p>
+          <p><a href="https://alice.example.com/groups/bob" rel="nofollow noopener" target="_blank">@alice/bob</a></p>
         EOS
         expect(result[:mentioned_groups]).to eq [{
           group_url_name: "bob",
@@ -857,7 +857,7 @@ describe Qiita::Markdown::Processor do
         { hostname: "qiita.com" }
       end
 
-      it "creates link which does not have rel='nofollow' and target='_blank'" do
+      it "creates link which does not have rel='nofollow noopener' and target='_blank'" do
         should eq(
           '<p><a href="http://qiita.com/?a=b" class="autolink">' \
           "http://qiita.com/?a=b</a></p>\n"
@@ -874,9 +874,9 @@ describe Qiita::Markdown::Processor do
         { hostname: "qiita.com" }
       end
 
-      it "creates link which has rel='nofollow' and target='_blank'" do
+      it "creates link which has rel='nofollow noopener' and target='_blank'" do
         should eq(
-          '<p><a href="http://external.com/?a=b" class="autolink" rel="nofollow" target="_blank">' \
+          '<p><a href="http://external.com/?a=b" class="autolink" rel="nofollow noopener" target="_blank">' \
           "http://external.com/?a=b</a></p>\n"
         )
       end
@@ -891,7 +891,7 @@ describe Qiita::Markdown::Processor do
         { hostname: "qiita.com" }
       end
 
-      it "creates link which does not have rel='nofollow' and target='_blank'" do
+      it "creates link which does not have rel='nofollow noopener' and target='_blank'" do
         should eq(
           "<p><a href=\"http://qiita.com/?a=b\">foobar</a></p>\n"
         )
@@ -907,9 +907,9 @@ describe Qiita::Markdown::Processor do
         { hostname: "qiita.com" }
       end
 
-      it "creates link which has rel='nofollow' and target='_blank'" do
+      it "creates link which has rel='nofollow noopener' and target='_blank'" do
         should eq(
-          "<p><a href=\"http://external.com/?a=b\" rel=\"nofollow\" target=\"_blank\">foobar</a></p>\n"
+          "<p><a href=\"http://external.com/?a=b\" rel=\"nofollow noopener\" target=\"_blank\">foobar</a></p>\n"
         )
       end
     end
@@ -923,9 +923,9 @@ describe Qiita::Markdown::Processor do
         { hostname: "qiita.com" }
       end
 
-      it "creates link which has rel='nofollow' and target='_blank'" do
+      it "creates link which has rel='nofollow noopener' and target='_blank'" do
         should eq(
-          '<p><a href="http://qqqqqqiita.com/?a=b" class="autolink" rel="nofollow" target="_blank">' \
+          '<p><a href="http://qqqqqqiita.com/?a=b" class="autolink" rel="nofollow noopener" target="_blank">' \
           "http://qqqqqqiita.com/?a=b</a></p>\n"
         )
       end
@@ -940,9 +940,9 @@ describe Qiita::Markdown::Processor do
         { hostname: "qiita.com" }
       end
 
-      it "creates link which has rel='nofollow' and target='_blank'" do
+      it "creates link which has rel='nofollow noopener' and target='_blank'" do
         should eq(
-          "<p><a href=\"http://qqqqqqiita.com/?a=b\" rel=\"nofollow\" target=\"_blank\">foobar</a></p>\n"
+          "<p><a href=\"http://qqqqqqiita.com/?a=b\" rel=\"nofollow noopener\" target=\"_blank\">foobar</a></p>\n"
         )
       end
     end
@@ -956,9 +956,9 @@ describe Qiita::Markdown::Processor do
         { hostname: "qiita.com" }
       end
 
-      it "creates link which has rel='nofollow' and target='_blank'" do
+      it "creates link which has rel='nofollow noopener' and target='_blank'" do
         should eq(
-          '<p><a href="http://sub.qiita.com/?a=b" class="autolink" rel="nofollow" target="_blank">' \
+          '<p><a href="http://sub.qiita.com/?a=b" class="autolink" rel="nofollow noopener" target="_blank">' \
           "http://sub.qiita.com/?a=b</a></p>\n"
         )
       end
@@ -973,9 +973,9 @@ describe Qiita::Markdown::Processor do
         { hostname: "qiita.com" }
       end
 
-      it "creates link which has rel='nofollow' and target='_blank', and rel value is overwritten" do
+      it "creates link which has rel='nofollow noopener' and target='_blank', and rel value is overwritten" do
         should eq(
-          "<p><a href=\"http://external.com/?a=b\" rel=\"nofollow\" target=\"_blank\">foobar</a></p>\n"
+          "<p><a href=\"http://external.com/?a=b\" rel=\"nofollow noopener\" target=\"_blank\">foobar</a></p>\n"
         )
       end
     end


### PR DESCRIPTION
When we added the rel="nofollow" and target="_blank" to the external links, some experts were wondering whether we would also think about adding rel="noopener" as well.

http://b.hatena.ne.jp/entry/blog.qiita.com/post/149486954709/externallinkattrib

rel="noopener" is described in the following blogs.

- https://mathiasbynens.github.io/rel-noopener/
- https://blog.jxck.io/entries/2016-06-12/noopener.html
- https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/

In short, it prevents users from being affected with some security attack.