### PR TITLE
Do not try to highlight code of unknown language

### DIFF
--- a/lib/qiita/markdown/filters/syntax_highlight.rb
+++ b/lib/qiita/markdown/filters/syntax_highlight.rb
@@ -61,7 +61,7 @@ module Qiita
           end
 
           def highlighted_node
-            if specific_language
+            if specific_language && Pygments::Lexer.find(specific_language)
               begin
                 highlight(specific_language).presence or raise
               rescue


### PR DESCRIPTION
Let SyntaxHighlightFilter ignore language specification if a lexer for the language doesn't exist.

## why

Passing unknown language name to `Pygments.highlight` crashes the backing Python process. It makes subsequent call to that method significantly slower.

```
[1] pry(main)> def measure_time; t = Time.now; yield rescue puts("raised"); Time.now - t end
=> :measure_time

[2] pry(main)> measure_time { Pygments.highlight("x", lexer: "ruby") }
=> 0.367079
# ^^^ slow because a Python process has started

[3] pry(main)> measure_time { Pygments.highlight("x", lexer: "ruby") }
=> 0.001574
 # ^^^ fast because of process reuse

[5] pry(main)> measure_time { Pygments.highlight("x", lexer: "unknown") }
raised
=> 0.00696
# ^^^ the process has crashed

[6] pry(main)> measure_time { Pygments.highlight("x", lexer: "ruby") }
raised
=> 0.28838
# ^^^ slow because another process has started
```