### PR TITLE
Fix wrong markdown text for gem badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qiita::Markdown
 
-[[![Gem](https://img.shields.io/gem/v/qiita-markdown.svg)]()](https://rubygems.org/gems/qiita-markdown)
+[![Gem Version](https://badge.fury.io/rb/qiita-markdown.svg)](https://badge.fury.io/rb/qiita-markdown)
 [![Build Status](https://travis-ci.org/increments/qiita-markdown.svg)](https://travis-ci.org/increments/qiita-markdown)
 [![Code Climate](https://codeclimate.com/github/increments/qiita-markdown/badges/gpa.svg)](https://codeclimate.com/github/increments/qiita-markdown)
 [![Test Coverage](https://codeclimate.com/github/increments/qiita-markdown/badges/coverage.svg)](https://codeclimate.com/github/increments/qiita-markdown)


### PR DESCRIPTION
seems gem badge markdown is broken. 

ref. https://badge.fury.io/for/rb/qiita-markdown