### PR TITLE
Pygments.rb 1.0

### DIFF
--- a/lib/qiita/markdown/filters/code.rb
+++ b/lib/qiita/markdown/filters/code.rb
@@ -28,9 +28,6 @@ module Qiita
                 filename: filename,
                 language: language,
               }
-              # a leading newline character immediately following the pre element start tag is stripped.
-              # http://dev.w3.org/html5/spec-preview/the-pre-element.html
-              pre.content = "\n#{pre.content}"
             end
           end
           doc

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "github-linguist", "~> 4.0"
   spec.add_dependency "html-pipeline", "~> 2.0"
   spec.add_dependency "mem"
-  spec.add_dependency "pygments.rb"
+  spec.add_dependency "pygments.rb", "~> 1.0"
   spec.add_dependency "greenmat", ">= 3.2.0.2", "< 4"
   spec.add_dependency "sanitize"
   spec.add_dependency "addressable"

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -117,8 +117,7 @@ describe Qiita::Markdown::Processor do
         should eq <<-EOS.strip_heredoc
           <div class="code-frame" data-lang="ruby">
           <div class="code-lang"><span class="bold">example.rb</span></div>
-          <div class="highlight"><pre>
-          <span class="mi">1</span>
+          <div class="highlight"><pre><span></span><span class="mi">1</span>
           </pre></div>
           </div>
         EOS
@@ -138,8 +137,7 @@ describe Qiita::Markdown::Processor do
         should eq <<-EOS.strip_heredoc
           <div class="code-frame" data-lang="php">
           <div class="code-lang"><span class="bold">example.php</span></div>
-          <div class="highlight"><pre>
-          <span class="mi">1</span>
+          <div class="highlight"><pre><span></span><span class="mi">1</span>
           </pre></div>
           </div>
         EOS
@@ -159,8 +157,7 @@ describe Qiita::Markdown::Processor do
         should eq <<-EOS.strip_heredoc
           <div class="code-frame" data-lang="js">
           <div class="code-lang"><span class="bold">test</span></div>
-          <div class="highlight"><pre>
-          <span class="mi">1</span>
+          <div class="highlight"><pre><span></span><span class="mi">1</span>
           </pre></div>
           </div>
         EOS
@@ -178,8 +175,7 @@ describe Qiita::Markdown::Processor do
 
       it "returns code-frame and highlighted pre element" do
         should eq <<-EOS.strip_heredoc
-          <div class="code-frame" data-lang="ruby"><div class="highlight"><pre>
-          <span class="mi">1</span>
+          <div class="code-frame" data-lang="ruby"><div class="highlight"><pre><span></span><span class="mi">1</span>
           </pre></div></div>
         EOS
       end
@@ -218,8 +214,7 @@ describe Qiita::Markdown::Processor do
 
       it "does not strip the newlines" do
         should eq <<-EOS.strip_heredoc
-          <div class="code-frame" data-lang="text"><div class="highlight"><pre>
-
+          <div class="code-frame" data-lang="text"><div class="highlight"><pre><span></span>
           foo
 
           </pre></div></div>
@@ -364,8 +359,7 @@ describe Qiita::Markdown::Processor do
         should include(<<-EOS.strip_heredoc.rstrip)
           <div class="code-frame" data-lang="ruby">
           <div class="code-lang"><span class="bold">@alice</span></div>
-          <div class="highlight"><pre>
-          <span class="mi">1</span>
+          <div class="highlight"><pre><span></span><span class="mi">1</span>
           </pre></div>
           </div>
         EOS
@@ -679,8 +673,7 @@ describe Qiita::Markdown::Processor do
 
       it "does not replace checkbox" do
         should eq <<-EOS.strip_heredoc
-          <div class="code-frame" data-lang="text"><div class="highlight"><pre>
-          - [ ] a
+          <div class="code-frame" data-lang="text"><div class="highlight"><pre><span></span>- [ ] a
           - [x] b
           </pre></div></div>
         EOS


### PR DESCRIPTION
We have added leading newline handling in #27 but it seems that the latest pygments (which is bundled with pygments.rb 1.0 or later) automatically prepends empty `<span></span>` element to preserve leading newlines. So our handling is now redundant.

## Before

![screen shot 2017-03-29 at 22 23 04](https://cloud.githubusercontent.com/assets/83656/24456583/68f86d24-14ce-11e7-8869-623f43b8bd0d.png)

## After

![screen shot 2017-03-29 at 22 21 56](https://cloud.githubusercontent.com/assets/83656/24456589/6cdef052-14ce-11e7-881b-7811338e244c.png)
