### PR TITLE
Drop 2.0 and 2.1 from support Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_install:
   - gem update bundler
 language: ruby
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
   - 2.3
   - 2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Drop 2.0 and 2.1 from support Ruby versions
+
 ## 0.18.0
 
 - Extract heading decoration logic from Greenmat renderer to `Toc` filter

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_dependency "gemoji"
   spec.add_dependency "github-linguist", "~> 4.0"


### PR DESCRIPTION
Since they are no longer maintained by the Ruby core team.