### PR TITLE
Allow <blockquote class="twitter-tweet">

### DIFF
--- a/lib/qiita/markdown/filters/user_input_sanitizer.rb
+++ b/lib/qiita/markdown/filters/user_input_sanitizer.rb
@@ -10,6 +10,9 @@ module Qiita
               "rel" => %w[footnote url],
               "rev" => %w[footnote],
             },
+            "blockquote" => {
+              "class" => %w[twitter-tweet],
+            },
             "div" => {
               "class" => %w[footnotes],
             },
@@ -63,7 +66,7 @@ module Qiita
           ],
           attributes: {
             "a"          => %w[class href rel title],
-            "blockquote" => %w[cite],
+            "blockquote" => %w[cite class],
             "code"       => %w[data-metadata],
             "div"        => %w[class],
             "font"       => %w[color],

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -1125,6 +1125,28 @@ describe Qiita::Markdown::Processor do
         end
       end
 
+      context "with class attribute for <blockquote> tag" do
+        let(:markdown) do
+          <<-EOS.strip_heredoc
+            <blockquote class="twitter-tweet malicious-class">foo</blockquote>
+          EOS
+        end
+
+        if allowed
+          it "does not sanitize the classes" do
+            should eq <<-EOS.strip_heredoc
+              <blockquote class="twitter-tweet malicious-class">foo</blockquote>
+            EOS
+          end
+        else
+          it "sanitizes classes except `twitter-tweet`" do
+            should eq <<-EOS.strip_heredoc
+              <blockquote class="twitter-tweet">foo</blockquote>
+            EOS
+          end
+        end
+      end
+
       context "with class attribute for <div> tag" do
         let(:markdown) do
           <<-EOS.strip_heredoc


### PR DESCRIPTION
## What
TSIA

## Why
Qiita had allowed users to embed tweets unofficially. Now we decided to support it officially.

## Note
Twitter widgets.js only depends on `blockquote.twitter-tweet > a[href]`. Any other attributes and inner text are not important.

> ![image](https://user-images.githubusercontent.com/96157/27275979-8c352eea-5514-11e7-81e7-7d6893ef2bc8.png)


