### PR TITLE
Allow <i class="fa fa-*"> except fa-spin

### DIFF
--- a/lib/qiita/markdown/filters/user_input_sanitizer.rb
+++ b/lib/qiita/markdown/filters/user_input_sanitizer.rb
@@ -22,6 +22,9 @@ module Qiita
             "li" => {
               "id" => /\Afn\d+\z/,
             },
+            "i" => {
+              "class" => /\Afa(?!-spin)(?:-[\w\-]+)*\z/,
+            },
           }.freeze
 
           DELIMITER = " ".freeze
@@ -83,6 +86,7 @@ module Qiita
             "sup"        => %w[id],
             "td"         => %w[colspan rowspan style],
             "th"         => %w[colspan rowspan style],
+            "i"          => %w[class],
           },
           protocols: {
             "a"          => { "href" => ["http", "https", "mailto", :relative] },

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -1086,16 +1086,32 @@ describe Qiita::Markdown::Processor do
     shared_examples_for "class attribute" do |allowed:|
       context "with class attribute for general tags" do
         let(:markdown) do
-          '<i class="fa fa-user"></i>user'
+          '<input type="button" class="btn">submit'
         end
 
         if allowed
           it "does not sanitize the attribute" do
-            should eq "<p><i class=\"fa fa-user\"></i>user</p>\n"
+            should eq %(<p><input type="button" class="btn">submit</p>\n)
           end
         else
           it "sanitizes the attribute" do
-            should eq "<p><i></i>user</p>\n"
+            should eq %(<p><input>submit</p>\n)
+          end
+        end
+      end
+
+      context "with class attribute for <i> tags" do
+        let(:markdown) do
+          '<i class="fa fa-user fa-spin btn"></i>user'
+        end
+
+        if allowed
+          it "does not sanitize the classes" do
+            should eq %(<p><i class="fa fa-user fa-spin btn"></i>user</p>\n)
+          end
+        else
+          it "sanitizes the classes just `fa` or start with `fa-` except `fa-spin`" do
+            should eq %(<p><i class="fa fa-user"></i>user</p>\n)
           end
         end
       end


### PR DESCRIPTION
Some Qiita users use FontAwesome for article headers.

c.f. [Qiita の記事の見出しに Font-Awesome を利用して見栄えを良くする #qiita by @tbpgr on @Qiita](http://qiita.com/tbpgr/items/361d8aaa38fb57d75216)