### PR TITLE
Embed CodePen when the CodePen url is provided

### DIFF
--- a/lib/qiita/markdown.rb
+++ b/lib/qiita/markdown.rb
@@ -9,6 +9,7 @@ require "sanitize"
 
 require "qiita/markdown/filters/checkbox"
 require "qiita/markdown/filters/code"
+require "qiita/markdown/filters/code_pen"
 require "qiita/markdown/filters/emoji"
 require "qiita/markdown/filters/external_link"
 require "qiita/markdown/filters/final_sanitizer"

--- a/lib/qiita/markdown/filters/code_pen.rb
+++ b/lib/qiita/markdown/filters/code_pen.rb
@@ -1,0 +1,64 @@
+require "addressable/uri"
+
+module Qiita
+  module Markdown
+    module Filters
+      class CodePen < HTML::Pipeline::Filter
+        HOST = "codepen.io".freeze
+        PATH_PATTERN = %r{\A/(?<username>\w+)/pen/(?<id>\w+)/?\z}
+
+        def call
+          doc.search("a").each do |anchor|
+            next unless anchor["href"]
+
+            href = anchor["href"].strip
+            next unless pen?(href)
+
+            iframe, = anchor.replace("<iframe>#{anchor.to_html}</iframe>")
+            add_iframe_attributes(iframe, href)
+          end
+
+          doc
+        end
+
+        private
+
+        def add_iframe_attributes(iframe, href)
+          m = PATH_PATTERN.match(path_of(href))
+          iframe["height"] = height = 500
+          iframe["scrolling"] = "no"
+          iframe["title"] = m[:id]
+          iframe["src"] = "//codepen.io/#{m[:username]}/embed/#{m[:id]}/?height=#{height}&theme-id=light&default-tab=html,result&embed-version=2"
+          iframe["frameborder"] = "no"
+          iframe["allowtransparency"] = "true"
+          iframe["allowfullscreen"] = "true"
+          iframe["style"] = "width: 100%;"
+        end
+
+        def host_of(url)
+          uri = Addressable::URI.parse(url)
+          uri.host
+        rescue Addressable::URI::InvalidURIError
+          nil
+        end
+
+        def path_of(url)
+          uri = Addressable::URI.parse(url)
+          uri.path
+        rescue Addressable::URI::InvalidURIError
+          nil
+        end
+
+        def pen?(href)
+          href_host = host_of(href)
+          return unless href_host == HOST
+
+          path = path_of(href)
+          return unless path
+
+          PATH_PATTERN =~ path
+        end
+      end
+    end
+  end
+end

--- a/lib/qiita/markdown/filters/final_sanitizer.rb
+++ b/lib/qiita/markdown/filters/final_sanitizer.rb
@@ -59,6 +59,7 @@ module Qiita
             ],
             "iframe" => [
               "allowfullscreen",
+              "allowtransparency",
               "frameborder",
               "height",
               "marginheight",
@@ -66,6 +67,7 @@ module Qiita
               "scrolling",
               "src",
               "style",
+              "title",
               "width",
             ],
             "img" => [
@@ -129,6 +131,7 @@ module Qiita
           css: {
             properties: [
               "text-align",
+              "width",
             ],
           },
           elements: [

--- a/lib/qiita/markdown/processor.rb
+++ b/lib/qiita/markdown/processor.rb
@@ -21,6 +21,7 @@ module Qiita
           Filters::Mention,
           Filters::GroupMention,
           Filters::ExternalLink,
+          Filters::CodePen,
           Filters::FinalSanitizer,
         ]
       end

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -1170,6 +1170,24 @@ describe Qiita::Markdown::Processor do
       end
     end
 
+    shared_examples_for "embed CodePen" do |allowed:|
+      context "with CodePen url" do
+        let(:markdown) do
+          "https://codepen.io/hanachin/pen/KqayLz"
+        end
+
+        if allowed
+          it "creates CodePen embed iframe" do
+            should eq(%(<p><iframe height="500" scrolling="no" title="KqayLz" src="//codepen.io/hanachin/embed/KqayLz/?height=500&amp;theme-id=light&amp;default-tab=html,result&amp;embed-version=2" frameborder="no" allowtransparency="true" allowfullscreen="true" style="width: 100%;"><a href="https://codepen.io/hanachin/pen/KqayLz" class="autolink" rel="nofollow noopener" target="_blank">https://codepen.io/hanachin/pen/KqayLz</a></iframe></p>\n))
+          end
+        else
+          it "creates CodePen link" do
+            should eq(%(<p><a href="https://codepen.io/hanachin/pen/KqayLz" class="autolink" rel="nofollow noopener" target="_blank">https://codepen.io/hanachin/pen/KqayLz</a></p>\n))
+          end
+        end
+      end
+    end
+
     context "without script and strict context" do
       let(:context) do
         super().merge(script: false, strict: false)
@@ -1181,6 +1199,7 @@ describe Qiita::Markdown::Processor do
       include_examples "iframe element", allowed: false
       include_examples "data-attributes", allowed: false
       include_examples "class attribute", allowed: true
+      include_examples "embed CodePen", allowed: false
     end
 
     context "with script context" do
@@ -1194,6 +1213,7 @@ describe Qiita::Markdown::Processor do
       include_examples "iframe element", allowed: true
       include_examples "data-attributes", allowed: true
       include_examples "class attribute", allowed: true
+      include_examples "embed CodePen", allowed: true
     end
 
     context "with strict context" do
@@ -1207,6 +1227,7 @@ describe Qiita::Markdown::Processor do
       include_examples "iframe element", allowed: false
       include_examples "data-attributes", allowed: false
       include_examples "class attribute", allowed: false
+      include_examples "embed CodePen", allowed: false
     end
 
     context "with script and strict context" do
@@ -1220,6 +1241,7 @@ describe Qiita::Markdown::Processor do
       include_examples "iframe element", allowed: false
       include_examples "data-attributes", allowed: false
       include_examples "class attribute", allowed: false
+      include_examples "embed CodePen", allowed: true
     end
   end
 end


### PR DESCRIPTION
I want to embed my codepen codes on my article.
http://qiita.com/hanachin_/items/e729dfd6a72b2c84842e