### PR TITLE
Allow data-canonical-src attribute of img tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Don't sanitize `data-canonical-src` attribute of `<img>`
+
 ## 0.20.1
 
 - Fix to sanitize `<input>` which was unexpectedly permitted

--- a/lib/qiita/markdown/filters/final_sanitizer.rb
+++ b/lib/qiita/markdown/filters/final_sanitizer.rb
@@ -70,6 +70,7 @@ module Qiita
             ],
             "img" => [
               "src",
+              "data-canonical-src",
             ],
             "input" => [
               "checked",

--- a/lib/qiita/markdown/filters/user_input_sanitizer.rb
+++ b/lib/qiita/markdown/filters/user_input_sanitizer.rb
@@ -76,7 +76,7 @@ module Qiita
             "h4"         => %w[id],
             "h5"         => %w[id],
             "h6"         => %w[id],
-            "img"        => %w[alt height src title width],
+            "img"        => %w[alt height src title width data-canonical-src],
             "ins"        => %w[cite datetime],
             "li"         => %w[id],
             "q"          => %w[cite],

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -1059,6 +1059,20 @@ describe Qiita::Markdown::Processor do
       end
     end
 
+    shared_examples_for "img element" do
+      context "with img element and data-canonical-src attribute" do
+        let(:markdown) do
+          <<-EOS.strip_heredoc.chomp
+            <img src="http://example.com" data-canonical-src="http://example.com">
+          EOS
+        end
+
+        it "allows the attribute" do
+          should include(markdown)
+        end
+      end
+    end
+
     shared_examples_for "input element" do |allowed:|
       context "with input" do
         let(:markdown) do
@@ -1199,6 +1213,7 @@ describe Qiita::Markdown::Processor do
       include_examples "script element", allowed: false
       include_examples "malicious script in filename", allowed: false
       include_examples "iframe element", allowed: false
+      include_examples "img element"
       include_examples "input element", allowed: true
       include_examples "data-attributes", allowed: false
       include_examples "class attribute", allowed: true
@@ -1213,6 +1228,7 @@ describe Qiita::Markdown::Processor do
       include_examples "script element", allowed: true
       include_examples "malicious script in filename", allowed: true
       include_examples "iframe element", allowed: true
+      include_examples "img element"
       include_examples "input element", allowed: true
       include_examples "data-attributes", allowed: true
       include_examples "class attribute", allowed: true
@@ -1227,6 +1243,7 @@ describe Qiita::Markdown::Processor do
       include_examples "script element", allowed: false
       include_examples "malicious script in filename", allowed: false
       include_examples "iframe element", allowed: false
+      include_examples "img element"
       include_examples "input element", allowed: false
       include_examples "data-attributes", allowed: false
       include_examples "class attribute", allowed: false
@@ -1241,6 +1258,7 @@ describe Qiita::Markdown::Processor do
       include_examples "script element", allowed: false
       include_examples "malicious script in filename", allowed: true
       include_examples "iframe element", allowed: false
+      include_examples "img element"
       include_examples "input element", allowed: false
       include_examples "data-attributes", allowed: false
       include_examples "class attribute", allowed: false


### PR DESCRIPTION
This PR lets FinalSanitizer and UserInputSanitizer allow `data-canonical-src` attribute of img tags set by [CamoFIlter](https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/camo_filter.rb).

This is because we are planing to replace external image urls by CamoFilter to deliver images through [Camo](https://github.com/atmos/camo).
