### PR TITLE
Strip and escape HTML tags in ToC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix to strip some tags in ToC
+
 ## 0.23.0
 
 - Support embed Tweet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Fix to strip some tags in ToC
+- Fix to strip HTML tags in ToC
 
 ## 0.23.0
 

--- a/lib/qiita/markdown/greenmat/html_toc_renderer.rb
+++ b/lib/qiita/markdown/greenmat/html_toc_renderer.rb
@@ -65,6 +65,23 @@ module Qiita
           def increment
             counter[id] += 1
           end
+
+          private
+
+          def body
+            escape_html? ? CGI.escape_html(raw_body) : html_valid_body
+          end
+
+          def html_valid_body
+            fragments = Nokogiri::HTML.fragment(raw_body)
+            strip_invalid_node(fragments)
+            fragments.to_s
+          end
+
+          def strip_invalid_node(node)
+            node.children.each { |child| strip_invalid_node(child) }
+            node.replace(node.children) if %w[ol ul li a].include?(node.name)
+          end
         end
       end
     end

--- a/lib/qiita/markdown/greenmat/html_toc_renderer.rb
+++ b/lib/qiita/markdown/greenmat/html_toc_renderer.rb
@@ -69,18 +69,7 @@ module Qiita
           private
 
           def body
-            escape_html? ? CGI.escape_html(raw_body) : html_valid_body
-          end
-
-          def html_valid_body
-            fragments = Nokogiri::HTML.fragment(raw_body)
-            strip_invalid_node(fragments)
-            fragments.to_s
-          end
-
-          def strip_invalid_node(node)
-            node.children.each { |child| strip_invalid_node(child) }
-            node.replace(node.children) if %w[ol ul li a].include?(node.name)
+            escape_html? ? CGI.escape_html(text) : raw_body
           end
         end
       end

--- a/spec/qiita/markdown/greenmat/html_toc_renderer_spec.rb
+++ b/spec/qiita/markdown/greenmat/html_toc_renderer_spec.rb
@@ -133,4 +133,94 @@ describe Qiita::Markdown::Greenmat::HTMLToCRenderer do
       EOS
     end
   end
+
+  context "with anchor tag" do
+    let(:markdown) do
+      <<-EOS.strip_heredoc
+        # <a href="#">foo</a>
+      EOS
+    end
+
+    it "strips anchor tag" do
+      should eq <<-EOS.strip_heredoc
+        <ul>
+        <li>
+        <a href="#foo">foo</a>
+        </li>
+        </ul>
+      EOS
+    end
+  end
+
+  context "with <ol> tag" do
+    let(:markdown) do
+      <<-EOS.strip_heredoc
+        # <ol>foo</ol>
+      EOS
+    end
+
+    it "strips <ol> tag" do
+      should eq <<-EOS.strip_heredoc
+        <ul>
+        <li>
+        <a href="#foo">foo</a>
+        </li>
+        </ul>
+      EOS
+    end
+  end
+
+  context "with <ul> tag" do
+    let(:markdown) do
+      <<-EOS.strip_heredoc
+        # <ul>foo</ul>
+      EOS
+    end
+
+    it "strips <ul> tag" do
+      should eq <<-EOS.strip_heredoc
+        <ul>
+        <li>
+        <a href="#foo">foo</a>
+        </li>
+        </ul>
+      EOS
+    end
+  end
+
+  context "with <li> tag" do
+    let(:markdown) do
+      <<-EOS.strip_heredoc
+        # <li>foo</li>
+      EOS
+    end
+
+    it "strips <li> tag" do
+      should eq <<-EOS.strip_heredoc
+        <ul>
+        <li>
+        <a href="#foo">foo</a>
+        </li>
+        </ul>
+      EOS
+    end
+  end
+
+  context "with <li> tag inside of <ul> tag" do
+    let(:markdown) do
+      <<-EOS.strip_heredoc
+        # <ul><li>foo</li></ul>
+      EOS
+    end
+
+    it "strips <ul> and <li> tag" do
+      should eq <<-EOS.strip_heredoc
+        <ul>
+        <li>
+        <a href="#foo">foo</a>
+        </li>
+        </ul>
+      EOS
+    end
+  end
 end

--- a/spec/qiita/markdown/greenmat/html_toc_renderer_spec.rb
+++ b/spec/qiita/markdown/greenmat/html_toc_renderer_spec.rb
@@ -117,110 +117,40 @@ describe Qiita::Markdown::Greenmat::HTMLToCRenderer do
   context "with :escape_html extension" do
     let(:extension) { { escape_html: true } }
 
-    let(:markdown) do
-      <<-EOS.strip_heredoc
-        # <b>R&amp;B</b>
-      EOS
+    context "with heading title including HTML tags" do
+      let(:markdown) do
+        <<-EOS.strip_heredoc
+          # <b>R&amp;B</b>
+        EOS
+      end
+
+      it "strips HTML characters in heading title" do
+        should eq <<-EOS.strip_heredoc
+          <ul>
+          <li>
+          <a href="#rb">R&amp;B</a>
+          </li>
+          </ul>
+        EOS
+      end
     end
 
-    it "escapes special HTML characters in heading title" do
-      should eq <<-EOS.strip_heredoc
-        <ul>
-        <li>
-        <a href="#rb">&lt;b&gt;R&amp;amp;B&lt;/b&gt;</a>
-        </li>
-        </ul>
-      EOS
-    end
-  end
+    context "with heading title including HTML tags inside of code" do
+      let(:markdown) do
+        <<-EOS.strip_heredoc
+          # `<div>`
+        EOS
+      end
 
-  context "with anchor tag" do
-    let(:markdown) do
-      <<-EOS.strip_heredoc
-        # <a href="#">foo</a>
-      EOS
-    end
-
-    it "strips anchor tag" do
-      should eq <<-EOS.strip_heredoc
-        <ul>
-        <li>
-        <a href="#foo">foo</a>
-        </li>
-        </ul>
-      EOS
-    end
-  end
-
-  context "with <ol> tag" do
-    let(:markdown) do
-      <<-EOS.strip_heredoc
-        # <ol>foo</ol>
-      EOS
-    end
-
-    it "strips <ol> tag" do
-      should eq <<-EOS.strip_heredoc
-        <ul>
-        <li>
-        <a href="#foo">foo</a>
-        </li>
-        </ul>
-      EOS
-    end
-  end
-
-  context "with <ul> tag" do
-    let(:markdown) do
-      <<-EOS.strip_heredoc
-        # <ul>foo</ul>
-      EOS
-    end
-
-    it "strips <ul> tag" do
-      should eq <<-EOS.strip_heredoc
-        <ul>
-        <li>
-        <a href="#foo">foo</a>
-        </li>
-        </ul>
-      EOS
-    end
-  end
-
-  context "with <li> tag" do
-    let(:markdown) do
-      <<-EOS.strip_heredoc
-        # <li>foo</li>
-      EOS
-    end
-
-    it "strips <li> tag" do
-      should eq <<-EOS.strip_heredoc
-        <ul>
-        <li>
-        <a href="#foo">foo</a>
-        </li>
-        </ul>
-      EOS
-    end
-  end
-
-  context "with <li> tag inside of <ul> tag" do
-    let(:markdown) do
-      <<-EOS.strip_heredoc
-        # <ul><li>foo</li></ul>
-      EOS
-    end
-
-    it "strips <ul> and <li> tag" do
-      should eq <<-EOS.strip_heredoc
-        <ul>
-        <li>
-        <a href="#foo">foo</a>
-        </li>
-        </ul>
-      EOS
+      it "escapes HTML tags inside of code" do
+        should eq <<-EOS.strip_heredoc
+          <ul>
+          <li>
+          <a href="#div">&lt;div&gt;</a>
+          </li>
+          </ul>
+        EOS
+      end
     end
   end
 end


### PR DESCRIPTION
## Why

When converting the following markdown to html,

```markdown
# <a href="#">hoge</a>
```

`<a>` tag gets nested when using HTMLToCRenderer.

```html
<ul>
<li>
<a href="#hoge"><a href="#">hoge</a></a>
</li>
</ul>
```

## What

- ~Strip `<ol>`, `<ul>`, `<li>`, `<a>` tags in HTMLToCRenderer~ -> Strip all html tags in HTMLToCRenderer when option of `:escape_html ` is true.

In the case of the above example, it becomes

```html
<ul>
<li>
<a href="#hoge">hoge</a>
</li>
</ul>
```

- Add some tests about it.
