### PR TITLE
Allow Asciinema script

### DIFF
--- a/lib/qiita/markdown.rb
+++ b/lib/qiita/markdown.rb
@@ -9,6 +9,7 @@ require "sanitize"
 
 require "qiita/markdown/embed/code_pen"
 require "qiita/markdown/embed/tweet"
+require "qiita/markdown/embed/asciinema"
 require "qiita/markdown/transformers/filter_attributes"
 require "qiita/markdown/transformers/filter_script"
 require "qiita/markdown/transformers/strip_invalid_node"

--- a/lib/qiita/markdown/embed/asciinema.rb
+++ b/lib/qiita/markdown/embed/asciinema.rb
@@ -1,0 +1,9 @@
+module Qiita
+  module Markdown
+    module Embed
+      module Asciinema
+        SCRIPT_HOST = "asciinema.org".freeze
+      end
+    end
+  end
+end

--- a/lib/qiita/markdown/filters/user_input_sanitizer.rb
+++ b/lib/qiita/markdown/filters/user_input_sanitizer.rb
@@ -26,7 +26,7 @@ module Qiita
             "li"         => %w[id],
             "p"          => Embed::CodePen::ATTRIBUTES,
             "q"          => %w[cite],
-            "script"     => %w[async src],
+            "script"     => %w[async src id],
             "sup"        => %w[id],
             "td"         => %w[colspan rowspan style],
             "th"         => %w[colspan rowspan style],

--- a/lib/qiita/markdown/transformers/filter_script.rb
+++ b/lib/qiita/markdown/transformers/filter_script.rb
@@ -2,9 +2,13 @@ module Qiita
   module Markdown
     module Transformers
       class FilterScript
-        WHITE_LIST = [
+        URL_WHITE_LIST = [
           Embed::CodePen::SCRIPT_URLS,
           Embed::Tweet::SCRIPT_URL,
+        ].flatten.freeze
+
+        HOST_WHITE_LIST = [
+          Embed::Asciinema::SCRIPT_HOST,
         ].flatten.freeze
 
         def self.call(*args)
@@ -17,7 +21,7 @@ module Qiita
 
         def transform
           if name == "script"
-            if WHITE_LIST.include?(node["src"])
+            if URL_WHITE_LIST.include?(node["src"]) || HOST_WHITE_LIST.include?(host_of(node["src"]))
               node["async"] = "async" unless node.attributes.key?("async")
               node.children.unlink
             else
@@ -34,6 +38,12 @@ module Qiita
 
         def node
           @env[:node]
+        end
+
+        def host_of(url)
+          Addressable::URI.parse(url).host if url
+        rescue Addressable::URI::InvalidURIError
+          nil
         end
       end
     end

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -1385,6 +1385,28 @@ describe Qiita::Markdown::Processor do
         end
       end
 
+      context "with HTML embed code for Asciinema" do
+        let(:markdown) do
+          <<-MARKDOWN.strip_heredoc
+            <script id="example" src="https://asciinema.org/a/example.js"></script>
+          MARKDOWN
+        end
+
+        if allowed
+          it "does not sanitize embed code" do
+            should eq <<-HTML.strip_heredoc
+              <script id="example" src="https://asciinema.org/a/example.js"></script>
+            HTML
+          end
+        else
+          it "forces async attribute on script" do
+            should eq <<-HTML.strip_heredoc
+              <script id="example" src="https://asciinema.org/a/example.js" async="async"></script>
+            HTML
+          end
+        end
+      end
+
       context "with embed code for Tweet" do
         let(:markdown) do
           <<-MARKDOWN.strip_heredoc


### PR DESCRIPTION
# What
For enabling to embed asciinema script in Qiita main body, I fixed to allow loading `https://asciinema.org/a/xxxx.js` by script filter
