### PR TITLE
Add new codepen embeded script url

### DIFF
--- a/lib/qiita/markdown/embed/code_pen.rb
+++ b/lib/qiita/markdown/embed/code_pen.rb
@@ -5,6 +5,7 @@ module Qiita
         SCRIPT_URLS = [
           "https://production-assets.codepen.io/assets/embed/ei.js",
           "https://static.codepen.io/assets/embed/ei.js",
+          "https://cpwebassets.codepen.io/assets/embed/ei.js",
         ]
         CLASS_NAME = %w[codepen]
         DATA_ATTRIBUTES = %w[


### PR DESCRIPTION
Closes https://github.com/increments/qiita-markdown/issues/70

## What
- Add new codepen embeded script url

- new url: https://cpwebassets.codepen.io/assets/embed/ei.js

## Ref
https://qiita.com/genbu-jp/questions/634956ea77ade61af6c3