### PR TITLE
Change syntax highlighter from pygments to rouge

### DIFF
--- a/lib/qiita/markdown.rb
+++ b/lib/qiita/markdown.rb
@@ -4,7 +4,7 @@ require "html/pipeline"
 require "linguist"
 require "mem"
 require "nokogiri"
-require "pygments"
+require "rouge"
 require "sanitize"
 
 require "qiita/markdown/embed/code_pen"

--- a/lib/qiita/markdown/filters/syntax_highlight.rb
+++ b/lib/qiita/markdown/filters/syntax_highlight.rb
@@ -4,6 +4,7 @@ module Qiita
       class SyntaxHighlight < HTML::Pipeline::Filter
         DEFAULT_LANGUAGE = "text"
         DEFAULT_TIMEOUT = Float::INFINITY
+        DEFAULT_OPTION = "html_legacy"
 
         def call
           elapsed = 0
@@ -79,11 +80,11 @@ module Qiita
           end
 
           def highlight(language)
-            Pygments.highlight(code, lexer: language, options: pygments_options)
+            Rouge.highlight(code, language, DEFAULT_OPTION)
           end
 
           def highlighted_node
-            if specific_language && Pygments::Lexer.find(specific_language)
+            if specific_language && Rouge::Lexer.find(specific_language)
               begin
                 highlight(specific_language).presence or raise
               rescue
@@ -100,14 +101,6 @@ module Qiita
 
           def language_node
             Nokogiri::HTML.fragment(%Q[<div class="code-frame" data-lang="#{language}"></div>])
-          end
-
-          def pygments_options
-            @pygments_options ||= begin
-              options = { encoding: "utf-8", stripnl: false }
-              options[:startinline] = true if has_inline_php?
-              options
-            end
           end
 
           def specific_language

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "github-linguist", "~> 4.0"
   spec.add_dependency "html-pipeline", "~> 2.0"
   spec.add_dependency "mem"
-  spec.add_dependency "pygments.rb", "~> 1.0"
+  spec.add_dependency "rouge", "3.26.0"
   spec.add_dependency "greenmat", "3.5.1.2"
   spec.add_dependency "sanitize"
   spec.add_dependency "addressable"

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -149,8 +149,8 @@ describe Qiita::Markdown::Processor do
           should eq <<-HTML.strip_heredoc
             <div class="code-frame" data-lang="ruby">
             <div class="code-lang"><span class="bold">example.rb</span></div>
-            <div class="highlight"><pre><span></span><span class="mi">1</span>
-            </pre></div>
+            <div class="highlight"><pre class="codehilite"><code><span class="mi">1</span>
+            </code></pre></div>
             </div>
           HTML
         end
@@ -169,8 +169,8 @@ describe Qiita::Markdown::Processor do
           should eq <<-HTML.strip_heredoc
             <div class="code-frame" data-lang="php">
             <div class="code-lang"><span class="bold">example.php</span></div>
-            <div class="highlight"><pre><span></span><span class="mi">1</span>
-            </pre></div>
+            <div class="highlight"><pre class="codehilite"><code><span class="mi">1</span>
+            </code></pre></div>
             </div>
           HTML
         end
@@ -187,8 +187,8 @@ describe Qiita::Markdown::Processor do
 
         it "returns code-frame and highlighted pre element" do
           should eq <<-HTML.strip_heredoc
-            <div class="code-frame" data-lang="ruby"><div class="highlight"><pre><span></span><span class="mi">1</span>
-            </pre></div></div>
+            <div class="code-frame" data-lang="ruby"><div class="highlight"><pre class="codehilite"><code><span class="mi">1</span>
+            </code></pre></div></div>
           HTML
         end
       end
@@ -226,10 +226,10 @@ describe Qiita::Markdown::Processor do
 
         it "does not strip the newlines" do
           should eq <<-HTML.strip_heredoc
-            <div class="code-frame" data-lang="text"><div class="highlight"><pre><span></span>
+            <div class="code-frame" data-lang="text"><div class="highlight"><pre class="codehilite"><code>
             foo
 
-            </pre></div></div>
+            </code></pre></div></div>
            HTML
         end
       end
@@ -311,8 +311,8 @@ describe Qiita::Markdown::Processor do
           should include(<<-HTML.strip_heredoc.rstrip)
             <div class="code-frame" data-lang="ruby">
             <div class="code-lang"><span class="bold">@alice</span></div>
-            <div class="highlight"><pre><span></span><span class="mi">1</span>
-            </pre></div>
+            <div class="highlight"><pre class="codehilite"><code><span class="mi">1</span>
+            </code></pre></div>
             </div>
           HTML
         end
@@ -659,9 +659,9 @@ describe Qiita::Markdown::Processor do
 
         it "does not replace checkbox" do
           should eq <<-HTML.strip_heredoc
-            <div class="code-frame" data-lang="text"><div class="highlight"><pre><span></span>- [ ] a
+            <div class="code-frame" data-lang="text"><div class="highlight"><pre class="codehilite"><code>- [ ] a
             - [x] b
-            </pre></div></div>
+            </code></pre></div></div>
           HTML
         end
       end
@@ -768,9 +768,9 @@ describe Qiita::Markdown::Processor do
 
         it "generates only code blocks without footnotes" do
           should eq <<-HTML.strip_heredoc
-            <div class="code-frame" data-lang="text"><div class="highlight"><pre><span></span>[^1]
+            <div class="code-frame" data-lang="text"><div class="highlight"><pre class="codehilite"><code>[^1]
             [^1]: test
-            </pre></div></div>
+            </code></pre></div></div>
           HTML
         end
       end
@@ -1067,8 +1067,8 @@ describe Qiita::Markdown::Processor do
           expect(subject).to eq <<-HTML.strip_heredoc
             <p><details><summary>Folding sample</summary><div>
 
-            <div class="code-frame" data-lang="rb"><div class="highlight"><pre><span></span><span class="nb">puts</span> <span class="s2">"Hello, World"</span>
-            </pre></div></div>
+            <div class="code-frame" data-lang="rb"><div class="highlight"><pre class="codehilite"><code><span class="nb">puts</span> <span class="s2">"Hello, World"</span>
+            </code></pre></div></div>
 
             <p></p>
             </div></details></p>
@@ -1124,8 +1124,8 @@ describe Qiita::Markdown::Processor do
             should eq <<-HTML.strip_heredoc
               <div class="code-frame" data-lang="js">
               <div class="code-lang"><span class="bold">test<script>alert(1)</script></span></div>
-              <div class="highlight"><pre><span></span><span class="mi">1</span>
-              </pre></div>
+              <div class="highlight"><pre class="codehilite"><code><span class="mi">1</span>
+              </code></pre></div>
               </div>
             HTML
           end
@@ -1134,8 +1134,8 @@ describe Qiita::Markdown::Processor do
             should eq <<-HTML.strip_heredoc
               <div class="code-frame" data-lang="js">
               <div class="code-lang"><span class="bold">test</span></div>
-              <div class="highlight"><pre><span></span><span class="mi">1</span>
-              </pre></div>
+              <div class="highlight"><pre class="codehilite"><code><span class="mi">1</span>
+              </code></pre></div>
               </div>
             HTML
           end


### PR DESCRIPTION
closes https://github.com/increments/qiita-markdown/issues/78
We stoped to use pygments in Qiita and Qiita Team, so change default syntax highlighter to rouge.