### PR TITLE
Fix bug when type of custom block is empty

### DIFF
--- a/lib/qiita/markdown/filters/custom_block.rb
+++ b/lib/qiita/markdown/filters/custom_block.rb
@@ -18,9 +18,11 @@ module Qiita
           attr_reader :type, :subtype
 
           # @param text [String, nil]
+          # @note Attribute `type` will be nil if `text` is nil
+          # @note Attribute `subtype` will be nil if `text` does not include white space.
           def initialize(text)
             # Discared after the second word.
-            @type, @subtype = text.split(" ")
+            @type, @subtype = text && text.split(" ")
           end
         end
 

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -1690,6 +1690,24 @@ describe Qiita::Markdown::Processor do
           MARKDOWN
         end
 
+        context "when type is empty" do
+          if allowed
+            it "returns simple div element" do
+              should eq <<-HTML.strip_heredoc
+                <div data-type="customblock">Some kind of text is here.
+                </div>
+              HTML
+            end
+          else
+            it "returns simple div element" do
+              should eq <<-HTML.strip_heredoc
+                <div>Some kind of text is here.
+                </div>
+              HTML
+            end
+          end
+        end
+
         context "when type is not allowed" do
           let(:type) { "anytype" }
 


### PR DESCRIPTION
- Fixed an error when custom block type is empty.
   - example
     ```
     :::
     Some messages
     :::
     ```
  - Parse to simple div element if type is empty.