### PR TITLE
Fix group url length

### DIFF
--- a/lib/qiita/markdown/filters/group_mention.rb
+++ b/lib/qiita/markdown/filters/group_mention.rb
@@ -22,7 +22,7 @@ module Qiita
             (?:^|\W)
             @((?>[a-z\d][a-z\d-]{2,31}))
             \/
-            ([A-Za-z\d][A-Za-z\d-]{0,14}[A-Za-z\d])
+            ([A-Za-z\d][A-Za-z\d-]{0,62}[A-Za-z\d])
             (?!\/)
             (?=
               \.+[ \t\W]|


### PR DESCRIPTION
## what
I fix regular expressions to detect group id(url_name) for group mention.
Max length group id changed form 16 to 64(please check ref).

## REF 
https://teams.qiita.com/guide/expand-group-char-limit/