### PR TITLE
Fix code metadata to allow containing colon

### DIFF
--- a/lib/qiita/markdown/filters/code_block.rb
+++ b/lib/qiita/markdown/filters/code_block.rb
@@ -90,7 +90,8 @@ module Qiita
           end
 
           def sections
-            @sections ||= (@text || "").split(":")
+            splited = (@text || "").split(":")
+            @sections ||= splited.length <= 2 ? splited : @text.split(":", 2)
           end
         end
       end

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -156,6 +156,26 @@ describe Qiita::Markdown::Processor do
         end
       end
 
+      context "with code & filename with `:`" do
+        let(:markdown) do
+          <<-MARKDOWN.strip_heredoc
+            ```ruby:test:example.rb
+            1
+            ```
+          MARKDOWN
+        end
+
+        it "returns code-frame, code-lang, and highlighted pre element" do
+          should eq <<-HTML.strip_heredoc
+            <div class="code-frame" data-lang="ruby">
+            <div class="code-lang"><span class="bold">test:example.rb</span></div>
+            <div class="highlight"><pre class="codehilite"><code><span class="mi">1</span>
+            </code></pre></div>
+            </div>
+          HTML
+        end
+      end
+
       context "with code & filename with .php" do
         let(:markdown) do
           <<-MARKDOWN.strip_heredoc


### PR DESCRIPTION
## What

I fixed to support file names containing colons.
For example, 

~~~markdown
```ruby:test:example.rb
hoge
```
~~~