### PR TITLE
Release v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.41.0
+
 - Bump greenmat from 3.5.1.2 to 3.5.1.3
 - Dropping Ruby 2.5 support (#107)
 - Bump rubocop from 0.40.0 to 1.7.0

--- a/lib/qiita/markdown/version.rb
+++ b/lib/qiita/markdown/version.rb
@@ -1,5 +1,5 @@
 module Qiita
   module Markdown
-    VERSION = "0.40.1"
+    VERSION = "0.41.0"
   end
 end


### PR DESCRIPTION
## Release v0.41.0

- [#113](https://github.com/increments/qiita-markdown/pull/113): Dropped Ruby 2.5 support by @mziyut
- [#114](https://github.com/increments/qiita-markdown/pull/114): Bump greenmat from 3.5.1.2 to 3.5.1.3 by @mziyut