### PR TITLE
Release v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 0.42.0
+
+- Add for Ruby 3.0, 3.1 support
 - Bump greenmat from 3.5.1.3 to 3.5.1.4
 
 ## 0.41.0

--- a/lib/qiita/markdown/version.rb
+++ b/lib/qiita/markdown/version.rb
@@ -1,5 +1,5 @@
 module Qiita
   module Markdown
-    VERSION = "0.41.0"
+    VERSION = "0.42.0"
   end
 end


### PR DESCRIPTION
## What's Changed

- Add for Ruby3.x support by @maedana in https://github.com/increments/qiita-markdown/pull/116
- Bump greenmat from 3.5.1.3 to 3.5.1.4 by @mziyut in (https://github.com/increments/qiita-markdown/pull/117