### PR TITLE
Fix bug of checkbox filter when space exists after checkbox mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix bug of checkbox filter
+
 ## 0.43.0
 
 - Fix GitHub Actions can't be executed when public fork

--- a/lib/qiita/markdown/filters/checkbox.rb
+++ b/lib/qiita/markdown/filters/checkbox.rb
@@ -31,7 +31,7 @@ module Qiita
           end
 
           def convert
-            first_text_node.content = first_text_node.content.sub(checkbox_mark, "")
+            first_text_node.content = first_text_node.content.sub(checkbox_mark, "").lstrip
             first_text_node.add_previous_sibling(checkbox_node)
             @node["class"] = "task-list-item"
           end

--- a/spec/qiita/markdown/filters/checkbox_spec.rb
+++ b/spec/qiita/markdown/filters/checkbox_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe Qiita::Markdown::Filters::Checkbox do
+  subject(:filter) do
+    described_class.new(input_html)
+  end
+
+  context "with checkbox" do
+    let(:input_html) do
+      <<~HTML
+        <li>[ ] a</li>
+        <li>[x] a</li>
+      HTML
+    end
+
+    let(:output_html) do
+      <<~HTML
+        <li class="task-list-item">
+        <input type="checkbox" class="task-list-item-checkbox" disabled>a</li>
+        <li class="task-list-item">
+        <input type="checkbox" class="task-list-item-checkbox" checked disabled>a</li>
+      HTML
+    end
+
+    it "replaces checkboxes" do
+      expect(filter.call.to_s).to eq(output_html)
+    end
+
+    context "when input html has many spaces after checkbox mark" do
+      let(:input_html) do
+        <<~HTML
+          <li>[ ]    a</li>
+          <li>[x]    a</li>
+        HTML
+      end
+
+      it "replaces checkboxes and remove spaces" do
+        expect(filter.call.to_s).to eq(output_html)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

I fixed bug of checkbox filter.

### Detail

When checkbox mark (`- [ ]`) is followed by many spaces,

```
- [ ] single space
- [ ]    many spaces
```

in GitHub, spaces are removed as follows.

- [ ] single space
- [ ]    many spaces

However, Qiita Markdown's checkbox filter does not remove. So I added `lstrip` to remove spaces.

