### PR TITLE
Rename pagkage name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Rename package name from `Qiita::Markdown` to `Qiita Markdown` in README
+
 ## 0.44.0
 
 - Support Figma embedding scripts

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Qiita::Markdown
+# Qiita Markdown
 
 [![Gem Version](https://badge.fury.io/rb/qiita-markdown.svg)](https://badge.fury.io/rb/qiita-markdown)
 [![Build Status](https://travis-ci.org/increments/qiita-markdown.svg)](https://travis-ci.org/increments/qiita-markdown)
@@ -42,7 +42,7 @@ processor.call(markdown)
 
 ### Filters
 
-Qiita::Markdown is built on [jch/html-pipeline](https://github.com/jch/html-pipeline).
+Qiita Markdown is built on [jch/html-pipeline](https://github.com/jch/html-pipeline).
 Add your favorite html-pipeline-compatible filters.
 
 ```ruby


### PR DESCRIPTION
Rename package name from `Qiita::Markdown` to `Qiita Markdown` in README