### PR TITLE
Release v0.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.44.1
+
 - Rename package name from `Qiita::Markdown` to `Qiita Markdown` in README
 - Bump rubocop from 1.27.0 to 1.39.0 and apply rubocop auto correct
 

--- a/lib/qiita/markdown/version.rb
+++ b/lib/qiita/markdown/version.rb
@@ -1,5 +1,5 @@
 module Qiita
   module Markdown
-    VERSION = "0.44.0"
+    VERSION = "0.44.1"
   end
 end


### PR DESCRIPTION
## Why

- #131 will be major version up and this version will be stable version of the version 0 series.

## Changes

- https://github.com/increments/qiita-markdown/pull/128
- https://github.com/increments/qiita-markdown/pull/129