### PR TITLE
Bump rake version to work with ruby 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bump rake version to work with ruby 3.2
+
 ## 1.0.2
 
 - Avoid sanitizing attributes related to footnotes

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "codeclimate-test-reporter", "0.4.4"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "rubocop", "~> 1.39.0"
   spec.add_development_dependency "simplecov", "!= 0.18.0", "!= 0.18.1", "!= 0.18.2", "!= 0.18.3", "!= 0.18.4", "!= 0.18.5", "!= 0.19.0", "!= 0.19.1"


### PR DESCRIPTION
## What
Closes https://github.com/increments/qiita-markdown/issues/133

- Bump rake version to work with ruby 3.2
    - There was a problem in previous version of rake that did not work due to braking changes in Ruby 3.2