### PR TITLE
Drop Ruby 2.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.7'
           bundler-cache: true
       - name: Test & publish code coverage
         if: "${{ env.CC_TEST_REPORTER_ID != '' }}"
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-18.04', 'ubuntu-latest', 'macos-latest']
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1']
         experimental: [false]
         include:
           - os: 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Drop Ruby 2.6 support
+
 ## 0.44.1
 
 - Rename package name from `Qiita::Markdown` to `Qiita Markdown` in README

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.add_dependency "addressable"
   spec.add_dependency "gemoji"


### PR DESCRIPTION
## What

- Drop ruby 2.6 support
    - ruby 2.6 is already EOL

## Reference

- https://www.ruby-lang.org/en/downloads/branches/