### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.0.0
+
 - Drop Ruby 2.6 support
 - Change markdown parser from Greenmat to Qiita Marker
 - Fix bug on rendering loose tasklist

--- a/lib/qiita/markdown/version.rb
+++ b/lib/qiita/markdown/version.rb
@@ -1,5 +1,5 @@
 module Qiita
   module Markdown
-    VERSION = "0.44.1"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
> **Warning**
> See [#130](https://github.com/increments/qiita-markdown/issues/130) for the breaking changes on some Markdown notations

## Releases

- https://github.com/increments/qiita-markdown/pull/131
- https://github.com/increments/qiita-markdown/pull/135