### PR TITLE
Allow attributes related to footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Avoid sanitizing attributes related to footnotes
+
 ## 1.0.1
 
 - Chenge qiita_marker from development dependency to runtime dependency

--- a/lib/qiita/markdown/transformers/filter_attributes.rb
+++ b/lib/qiita/markdown/transformers/filter_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Qiita
   module Markdown
     module Transformers
@@ -7,6 +9,7 @@ module Qiita
             "class" => %w[autolink],
             "rel" => %w[footnote url],
             "rev" => %w[footnote],
+            "id" => /\Afnref-.+\z/,
           },
           "blockquote" => {
             "class" => Embed::Tweet::CLASS_NAME,
@@ -17,15 +20,18 @@ module Qiita
           "p" => {
             "class" => Embed::CodePen::CLASS_NAME,
           },
+          "section" => {
+            "class" => %w[footnotes],
+          },
           "sup" => {
             "id" => /\Afnref\d+\z/,
           },
           "li" => {
-            "id" => /\Afn\d+\z/,
+            "id" => /\Afn.+\z/,
           },
         }.freeze
 
-        DELIMITER = " ".freeze
+        DELIMITER = " "
 
         def self.call(**args)
           new(**args).transform


### PR DESCRIPTION
## What

- Avoid sanitizing attributes related to footnotes
    - To fix a bug that links to footnotes were disabled