### PR TITLE
Bump rouge from 3.26.0 to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Bump rake version to work with ruby 3.2
+- Bump rouge 3.26.0 to 4.1.0
 
 ## 1.0.2
 

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "html-pipeline", "~> 2.0"
   spec.add_dependency "mem"
   spec.add_dependency "qiita_marker", "~> 0.23.6"
-  spec.add_dependency "rouge", "3.26.0"
+  spec.add_dependency "rouge", "~> 4.1.0"
   spec.add_dependency "sanitize"
   spec.add_development_dependency "activesupport", "~> 5.2.7"
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
Update rouge dependency.

Mainly breaking change is stop to support solidly lexer.

https://github.com/rouge-ruby/rouge/releases
https://github.com/rouge-ruby/rouge/compare/v3.26.0...v4.1.0
https://github.com/rouge-ruby/rouge/blob/master/CHANGELOG.md