### PR TITLE
Bump qiita marker 0.23.6 to 0.23.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
       - name: Test & publish code coverage
         if: "${{ env.CC_TEST_REPORTER_ID != '' }}"
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-18.04', 'ubuntu-latest', 'macos-latest']
-        ruby: ['2.7', '3.0', '3.1']
+        ruby: ['3.0', '3.1']
         experimental: [false]
         include:
           - os: 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-18.04', 'ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-latest']
         ruby: ['3.0', '3.1']
         experimental: [false]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Drop Ruby 2.7 support
+- Bump qiita_marker 0.23.6 to 0.23.9
+- Drop Ubuntu 18.04 support
+
 # 1.0.3
 
 - Bump rake version to work with ruby 3.2

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency "addressable"
   spec.add_dependency "gemoji"

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "github-linguist", "~> 4.0"
   spec.add_dependency "html-pipeline", "~> 2.0"
   spec.add_dependency "mem"
-  spec.add_dependency "qiita_marker", "~> 0.23.6"
+  spec.add_dependency "qiita_marker", "~> 0.23.9"
   spec.add_dependency "rouge", "~> 4.1.0"
   spec.add_dependency "sanitize"
   spec.add_development_dependency "activesupport", "~> 5.2.7"


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What

- Drop Ruby 2.7 support
    - ruby 2.7 is already EOL
    - qiita_marker-0.23.9 required Ruby >= 3.0
- Bump qiita_marker 0.23.6 to 0.23.9
    - https://github.com/increments/qiita_marker/pull/40
- Drop Ubuntu 18.04 support
    - Ubuntu 18.04 is already EOL

## Why

- Drop Ubuntu 18.04 support
    - Because GitHub Actions fail jobs using Ubuntu 18.04
        - https://github.com/increments/qiita-markdown/actions/runs/4988480359/jobs/9089846191
        - https://github.com/actions/runner-images/issues/6002

## Reference

- https://www.ruby-lang.org/en/downloads/branches/