### PR TITLE
Upgrade github-linguist from 4.x to 7.x

### DIFF
--- a/lib/qiita/markdown/filters/code_block.rb
+++ b/lib/qiita/markdown/filters/code_block.rb
@@ -86,7 +86,7 @@ module Qiita
           end
 
           def linguist_language
-            @linguist_language ||= Linguist::Language.find_by_filename(filename).first
+            @linguist_language ||= Linguist::Language.find_by_extension(filename).first
           end
 
           def sections

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable"
   spec.add_dependency "gemoji"
-  spec.add_dependency "github-linguist", "~> 4.0"
+  spec.add_dependency "github-linguist", "~> 7.0"
   spec.add_dependency "html-pipeline", "~> 2.0"
   spec.add_dependency "mem"
   spec.add_dependency "qiita_marker", "~> 0.23.9"


### PR DESCRIPTION
I have trouble to install 1.6.x of rugged. The following error has occurred.
```
Installing rugged 1.6.3 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.                                                     
                                                                                                                       
    current directory: /home/maedana/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rugged-1.6.3/ext/rugged            
/home/maedana/.rbenv/versions/3.2.2/bin/ruby extconf.rb --use-system-libraries                                         
checking for gmake... no                                                                                               
checking for make... yes                                                                                               
Building Rugged using system libraries.                                                                                
libgit2 version is not compatible, expected ~> 1.6.0                                                   
...
```
The latest version of rugged is 1.7.x. I could work around this by bringing github-linguist up to date.
The following PR solved the problem in my environment, and I confirmed that RSpec also passes.