### PR TITLE
Update rouge dependency version to '~> 4.2'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Add base64 to dependency
+- Bump rouge 4.1.0 to 4.2.0
 
 # 1.0.4
 

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "html-pipeline", "~> 2.0"
   spec.add_dependency "mem"
   spec.add_dependency "qiita_marker", "~> 0.23.9"
-  spec.add_dependency "rouge", "~> 4.1.0"
+  spec.add_dependency "rouge", "~> 4.2"
   spec.add_dependency "sanitize"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
Update rouge dependency.

CHANGELOG

https://github.com/rouge-ruby/rouge/blob/master/CHANGELOG.md#version-420-2023-10-25

There is no breaking change.