### PR TITLE
Update rubocop for Ruby 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Add base64 to dependency
 
 # 1.0.4
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,12 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in qiita-markdown.gemspec
 gemspec
+
+gem "activesupport", "~> 5.2.7"
+gem "bundler"
+gem "codeclimate-test-reporter", "0.4.4"
+gem "pry"
+gem "rake"
+gem "rspec", "~> 3.1"
+gem "rubocop", "~> 1.60.2"
+gem "simplecov", "!= 0.18.0", "!= 0.18.1", "!= 0.18.2", "!= 0.18.3", "!= 0.18.4", "!= 0.18.5", "!= 0.19.0", "!= 0.19.1"

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "rubocop", "~> 1.39.0"
+  spec.add_development_dependency "rubocop", "~> 1.60.2"
   spec.add_development_dependency "simplecov", "!= 0.18.0", "!= 0.18.1", "!= 0.18.2", "!= 0.18.3", "!= 0.18.4", "!= 0.18.5", "!= 0.19.0", "!= 0.19.1"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -25,13 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "qiita_marker", "~> 0.23.9"
   spec.add_dependency "rouge", "~> 4.1.0"
   spec.add_dependency "sanitize"
-  spec.add_development_dependency "activesupport", "~> 5.2.7"
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "codeclimate-test-reporter", "0.4.4"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "rubocop", "~> 1.60.2"
-  spec.add_development_dependency "simplecov", "!= 0.18.0", "!= 0.18.1", "!= 0.18.2", "!= 0.18.3", "!= 0.18.4", "!= 0.18.5", "!= 0.19.0", "!= 0.19.1"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

`base64` is no longer be part of Ruby 3.4.0.
This PR is for adopting this update.

## Ref
https://github.com/increments/qiita-markdown/actions/runs/7690101297/job/20953534987?pr=151

> /home/runner/work/qiita-markdown/qiita-markdown/vendor/bundle/ruby/3.4.0+0/gems/rubocop-1.39.0/lib/rubocop/formatter/html_formatter.rb:6: warning: base64 was loaded from the standard library, but is not part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.