### PR TITLE
Add uri to require list for ruby 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Add uri to requiring libraries
 - Add base64 to dependency
 - Bump rouge 4.1.0 to 4.2.0
 

--- a/lib/qiita/markdown.rb
+++ b/lib/qiita/markdown.rb
@@ -6,6 +6,7 @@ require "nokogiri"
 require "qiita_marker"
 require "rouge"
 require "sanitize"
+require "uri"
 
 require "qiita/markdown/embed/code_pen"
 require "qiita/markdown/embed/tweet"


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

Ruby 3.4 does not support `uri` modules by default.
This PR is for adopting this update.

## Ref
https://github.com/increments/qiita-markdown/actions/runs/7704576731/job/20997185179?pr=153

```
# NameError:
#   uninitialized constant Qiita::Markdown::Transformers::FilterIframe::URI
#   ./lib/qiita/markdown/transformers/filter_iframe.rb:46:in `host_of'
```