### PR TITLE
Allow open attribute on details

### DIFF
--- a/lib/qiita/markdown/filters/final_sanitizer.rb
+++ b/lib/qiita/markdown/filters/final_sanitizer.rb
@@ -63,6 +63,9 @@ module Qiita
             "th" => [
               "style",
             ],
+            "details" => [
+              "open",
+            ],
             "video" => %w[
               src
               autoplay

--- a/lib/qiita/markdown/filters/user_input_sanitizer.rb
+++ b/lib/qiita/markdown/filters/user_input_sanitizer.rb
@@ -16,6 +16,7 @@ module Qiita
             "blockquote" => %w[cite] + Embed::Tweet::ATTRIBUTES,
             "code" => %w[data-metadata],
             "div" => %w[class data-type data-metadata],
+            "details" => %w[open],
             "font" => %w[color],
             "h1" => %w[id],
             "h2" => %w[id],

--- a/spec/qiita/markdown/processor_spec.rb
+++ b/spec/qiita/markdown/processor_spec.rb
@@ -1067,6 +1067,11 @@ describe Qiita::Markdown::Processor do
             puts "Hello, World"
             ```
             </div></details>
+
+            <details open close><summary>Folding sample2</summary>
+
+            it allows open attributes
+            </details>
           MARKDOWN
         end
 
@@ -1076,6 +1081,9 @@ describe Qiita::Markdown::Processor do
             <div class="code-frame" data-lang="rb"><div class="highlight"><pre class="codehilite"><code><span class="nb">puts</span> <span class="s2">"Hello, World"</span>
             </code></pre></div></div>
             </div></details>
+            <details open><summary>Folding sample2</summary>
+            <p>it allows open attributes</p>
+            </details>
           HTML
         end
       end


### PR DESCRIPTION
## What

- allow `open` attribute in `details` element

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
