### PR TITLE
Bump Ruby version on ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.2'
           bundler-cache: true
       - name: Test & publish code coverage
         if: "${{ env.CC_TEST_REPORTER_ID != '' }}"
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        ruby: ['3.0', '3.1']
+        ruby: ['3.2', '3.3', '3.4']
         experimental: [false]
         include:
           - os: 'ubuntu-latest'


### PR DESCRIPTION
# What

Close https://github.com/increments/qiita-markdown/issues/145

- Bump Ruby version on ci

# Refs

- https://www.ruby-lang.org/en/downloads/branches/

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
