### PR TITLE
Add workflow for releasing gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    environment: release
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1.245.0
+        with:
+          ruby-version: 3.4.4 # Latest stable Ruby for release builds
+          bundler-cache: true
+      - uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

## What

- Add GitHub Actions workflow for releasing gem to RubyGems.org
  - Use https://github.com/rubygems/release-gem

## Why

- We always execute the release command locally

## Refs

- https://github.com/increments/graphql-kaminari_connection/pull/36
- Already setup RubyGems Trusted Publishing
  - https://github.com/increments/qiita-dev/issues/7383#issuecomment-2975145721
- Already setup `release` environment
  - https://github.com/increments/qiita-dev/issues/7383#issuecomment-2975362104