### PR TITLE
Remove codeclimate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,27 +11,6 @@ permissions:
   contents: read
 
 jobs:
-  codeclimate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get branch names
-        id: branch-name
-        uses: tj-actions/branch-names@dde14ac574a8b9b1cedc59a1cf312788af43d8d8 # v8.2.1
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      - uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
-      - name: Test & publish code coverage
-        if: "${{ env.CC_TEST_REPORTER_ID != '' }}"
-        uses: paambaati/codeclimate-action@7bcf9e73c0ee77d178e72c0ec69f1a99c1afc1f3 # v2.7.5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-          GIT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
-          GIT_COMMIT_SHA: ${{ github.sha }}
-        with:
-          coverageCommand: bundle exec rake
-
   test:
     strategy:
       fail-fast: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 
 gem "activesupport", "~> 5.2.7"
 gem "bundler"
-gem "codeclimate-test-reporter", "0.4.4"
 gem "pry"
 gem "rake"
 gem "rspec", "~> 3.1"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/qiita-markdown.svg)](https://badge.fury.io/rb/qiita-markdown)
 [![Build Status](https://travis-ci.org/increments/qiita-markdown.svg)](https://travis-ci.org/increments/qiita-markdown)
-[![Code Climate](https://codeclimate.com/github/increments/qiita-markdown/badges/gpa.svg)](https://codeclimate.com/github/increments/qiita-markdown)
-[![Test Coverage](https://codeclimate.com/github/increments/qiita-markdown/badges/coverage.svg)](https://codeclimate.com/github/increments/qiita-markdown)
 
 Qiita-specified markdown processor.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
 if ENV["CI"]
-  if ENV["GITHUB_ACTIONS"]
-    require "simplecov"
-    SimpleCov.start
-  else
-    require "codeclimate-test-reporter"
-    CodeClimate::TestReporter.start
-  end
+  require "simplecov"
+  SimpleCov.start
 end
 
 require "qiita-markdown"


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What

- Remove use codeclimate

## How

- Remove codeclimate badge from README
- Stop use and uninstall codeclimate-test-reporter gem
- Remove codeclimate CI

## Why
- Code Climate API was disabled
    - https://docs.qlty.sh/migration/guide