### PR TITLE
Add a dependency on the uri gem to use version 1.0.4 or higher.

### DIFF
--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "qiita_marker", "~> 0.23.9"
   spec.add_dependency "rouge", "~> 4.2"
   spec.add_dependency "sanitize"
+  spec.add_dependency "uri", ">= 1.0.4"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What
- Add a dependency on the uri gem to use version 1.0.4 or higher.

## Why
- A vulnerability was found in the uri gem versions 1.0.3 and earlier.
    - [CVE-2025-61594: URI Credential Leakage Bypass previous fixes](https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/)

## Ref

- https://github.com/ruby/uri/compare/v1.0.3...v1.0.4