### PR TITLE
Drop Ruby 3.0, 3.1, 3.2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        ruby: ['3.2', '3.3', '3.4']
+        ruby: ['3.3', '3.4']
         experimental: [false]
         include:
           - os: 'ubuntu-latest'
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: Test
         run: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Drop Ruby 3.0, 3.1, 3.2 support
+
 ## 1.7.0
 
 - Support for embedding Claude Artifacts iframes

--- a/qiita-markdown.gemspec
+++ b/qiita-markdown.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = [">= 3.3.0", "< 4.0"]
 
   spec.add_dependency "addressable"
   spec.add_dependency "gemoji"


### PR DESCRIPTION
## What

Drop Ruby 3.0, 3.1, 3.2 support.

- Bump `required_ruby_version` from `>= 3.0.0` to `>= 3.3.0, < 4.0`
- Remove Ruby 3.2 from CI matrix (EOL: 2026-04-01)
- Update qlty job Ruby version from 3.2 to 3.3

## Refs

- #171
