### PR TITLE
Ignore html-pipeline major version updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     rebase-strategy: "disabled"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "html-pipeline"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directories:


### PR DESCRIPTION
## What

Exclude html-pipeline major version updates (3.x) from Dependabot.

## Why

html-pipeline 3.x replaces Nokogiri with Selma (Rust-based) as the internal HTML processing engine. Its `NodeFilter` runs all filters in a single `Selma::Rewriter` pass, which is structurally incompatible with qiita-markdown's sequential filter composition model. We decided to stay on 2.x.

## How

Added an `ignore` rule with `update-types: ["version-update:semver-major"]` for `html-pipeline` to the bundler section. Patch/minor updates within 2.x continue to be tracked.

## Refs

- #171
