### PR TITLE
Fix html-pipeline ignore rule to use versions constraint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       default-days: 7
     ignore:
       - dependency-name: "html-pipeline"
-        update-types: ["version-update:semver-major"]
+        versions: [">=3.0"]
 
   - package-ecosystem: "github-actions"
     directories:


### PR DESCRIPTION
## What

Fix html-pipeline ignore rule to use `versions` instead of `update-types`.

## Why

`update-types: ["version-update:semver-major"]` did not block #265 because dependabot-core could not resolve the dependency version from the gemspec range constraint (`~> 2.0`), causing the update-types filter to be silently skipped.

## How

<!-- diff shows the change -->

## Refs

- #264
- #265
