### PR TITLE
Stop running Ruby head CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,12 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest']
         ruby: ['3.3', '3.4']
         experimental: [false]
-        include:
-          - os: 'ubuntu-latest'
-            ruby: 'head'
-            experimental: true
+        # Temporarily disabled: qiita_marker does not support Ruby 4 yet
+        # See: https://github.com/increments/qiita-markdown/issues/268
+        # include:
+        #   - os: 'ubuntu-latest'
+        #     ruby: 'head'
+        #     experimental: true
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:


### PR DESCRIPTION
## What

- Links https://github.com/increments/qiita-markdown/issues/268
- Commented out the experimental Ruby head CI matrix entry (`test (ubuntu-latest, head, true)`)

## Why

- qiita_marker does not support Ruby 4 yet, so CI on Ruby head has been failing
- Who will own the Ruby 4 support work is still being discussed, so this just stops the currently failing job for now

## How

- Commented out the `include` block (the Ruby head matrix entry) in `.github/workflows/test.yml`, and left a link to the tracking issue so it's easy to find when re-enabling